### PR TITLE
Parse `import Thing ...` in the same way as `import {default as Thing} ...`

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2541,7 +2541,6 @@
     if (tokType === _string) {
       node.specifiers = [];
       node.source = parseExprAtom();
-      node.kind = "";
     } else {
       node.specifiers = parseImportSpecifiers();
       if (tokType !== _name || tokVal !== "from") unexpected();
@@ -2559,10 +2558,11 @@
     if (tokType === _name) {
       // import defaultObj, { x, y as z } from '...'
       var node = startNode();
-      node.id = parseIdent();
-      checkLVal(node.id, true);
-      node.name = null;
-      node['default'] = true;
+      node.id = startNode();
+      node.name = parseIdent();
+      checkLVal(node.name, true);
+      node.id.name = "default";
+      finishNode(node.id, "Identifier");
       nodes.push(finishNode(node, "ImportSpecifier"));
       if (!eat(_comma)) return nodes;
     }

--- a/acorn_loose.js
+++ b/acorn_loose.js
@@ -1016,9 +1016,10 @@
     } else {
       if (token.type === tt.name && token.value !== "from") {
         var elt = startNode();
-        elt.id = parseIdent();
-        elt.name = null;
-        elt['default'] = true;
+        elt.id = startNode();
+        elt.name = parseIdent();
+        elt.id.name = "default";
+        finishNode(elt.id, "Identifier");
         finishNode(elt, "ImportSpecifier");
         eat(tt.comma);
       }

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -5154,13 +5154,20 @@ test("import $ from \"jquery\"", {
       type: "ImportSpecifier",
       id: {
         type: "Identifier",
+        name: "default",
+        loc: {
+          start: {line: 1, column: 7},
+          end: {line: 1, column: 8}
+        }
+      },
+      name: {
+        type: "Identifier",
         name: "$",
         loc: {
           start: {line: 1, column: 7},
           end: {line: 1, column: 8}
         }
       },
-      name: null,
       loc: {
         start: {line: 1, column: 7},
         end: {line: 1, column: 8}
@@ -5328,10 +5335,16 @@ test("import crypto, { decrypt, encrypt as enc } from \"crypto\"", {
             start: {line: 1, column: 7},
             end: {line: 1, column: 13}
           },
-          name: "crypto"
+          name: "default"
         },
-        name: null,
-        default: true
+        name: {
+          type: "Identifier",
+          loc: {
+            start: {line: 1, column: 7},
+            end: {line: 1, column: 13}
+          },
+          name: "crypto"
+        }
       },
       {
         type: "ImportSpecifier",
@@ -14171,10 +14184,12 @@ test("import foo, * as bar from 'baz';", {
         type: "ImportSpecifier",
         id: {
           type: "Identifier",
-          name: "foo"
+          name: "default"
         },
-        name: null,
-        default: true
+        name: {
+          type: "Identifier",
+          name: "foo"
+        }
       },
       {
         type: "ImportBatchSpecifier",


### PR DESCRIPTION
Adjusts output with Reflect.parse output and simplifies handling of default imports
case by providing regular named ImportSpecifier.