### PR TITLE
Add support for running just the tokenizer to the bin/acorn script

### DIFF
--- a/bin/acorn
+++ b/bin/acorn
@@ -4,12 +4,12 @@ var path = require("path");
 var fs = require("fs");
 var acorn = require("../acorn.js");
 
-var infile, parsed, options = {}, silent = false, compact = false;
+var infile, parsed, tokens, options = {}, silent = false, compact = false, tokenize = false;
 
 function help(status) {
   var print = (status == 0) ? console.log : console.error;
   print("usage: " + path.basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6] [--strictSemicolons]");
-  print("        [--locations] [--compact] [--silent] [--help] [--] infile");
+  print("        [--tokenize] [--locations] [--compact] [--silent] [--help] [--] infile");
   process.exit(status);
 }
 
@@ -25,16 +25,29 @@ for (var i = 2; i < process.argv.length; ++i) {
   else if (arg == "--silent") silent = true;
   else if (arg == "--compact") compact = true;
   else if (arg == "--help") help(0);
+  else if (arg == "--tokenize") tokenize = true;
   else help(1);
 }
 
 try {
   var code = fs.readFileSync(infile, "utf8");
-  parsed = acorn.parse(code, options);
+
+  if (!tokenize)
+    parsed = acorn.parse(code, options);
+  else {
+    var get = acorn.tokenize(code, options);
+    tokens = [];
+    while (true) {
+      var token = get();
+      tokens.push(token);
+      if (token.type.type == "eof")
+        break;
+    }
+  }
 } catch(e) {
   console.log(e.message);
   process.exit(1);
 }
 
 if (!silent)
-  console.log(JSON.stringify(parsed, null, compact ? null : 2));
+  console.log(JSON.stringify(tokenize ? tokens : parsed, null, compact ? null : 2));


### PR DESCRIPTION
This PR adds a `--tokenize` flag to the `bin/acorn` script. When set, it tokenizes the input file rather than parsing it.