### PR TITLE
Add stray semicolons as class elements

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2393,6 +2393,8 @@
     classBody.body = [];
     expect(_braceL);
     while (!eat(_braceR)) {
+      while (eat(_semi));
+      if (tokType === _braceR) continue;
       var method = startNode();
       if (tokType === _name && tokVal === "static") {
         next();
@@ -2412,7 +2414,6 @@
       }
       method.value = parseMethod(isGenerator);
       classBody.body.push(finishNode(method, "MethodDefinition"));
-      eat(_semi);
     }
     node.body = finishNode(classBody, "ClassBody");
     return finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -8541,6 +8541,42 @@ test("class A { foo() {} get foo() {} }",{
   locations: true
 });
 
+test("class Semicolon { ; }", {
+  type: "Program",
+  loc: {
+    start: {line: 1, column: 0},
+    end: {line: 1, column: 21}
+  },
+  body: [{
+    type: "ClassDeclaration",
+    loc: {
+      start: {line: 1, column: 0},
+      end: {line: 1, column: 21}
+    },
+    id: {
+      type: "Identifier",
+      loc: {
+        start: {line: 1, column: 6},
+        end: {line: 1, column: 15}
+      },
+      name: "Semicolon"
+    },
+    superClass: null,
+    body: {
+      type: "ClassBody",
+      loc: {
+        start: {line: 1, column: 16},
+        end: {line: 1, column: 21}
+      },
+      body: []
+    }
+  }]
+}, {
+  ecmaVersion: 6,
+  ranges: true,
+  locations: true
+});
+
 // ES6: Computed Properties
 
 test("({[x]: 10})", {


### PR DESCRIPTION
14.5

> *ClassElement*[Yield] : 
>      *MethodDefinition*[?Yield]
>      **static** *MethodDefinition*[?Yield]
>      **;**