### PR TITLE
Support import and export declarations in acorn/util/walk

### DIFF
--- a/util/walk.js
+++ b/util/walk.js
@@ -295,8 +295,8 @@
     });
   };
   base.ImportSpecifier = function (node, st, c) {
-    c(node.id, st, 'Identifier');
     if (node.name) c(node.name, st, 'Identifier');
+    else c(node.id, st, 'Identifier');
   };
   base.ImportBatchSpecifier = function (node, st, c) {
     c(node.name, st, 'Identifier');

--- a/util/walk.js
+++ b/util/walk.js
@@ -289,19 +289,11 @@
     c(node.declaration, st);
   };
   base.ImportDeclaration = function (node, st, c) {
-    c(node.source, st, 'Literal');
     node.specifiers.forEach(function (specifier) {
       c(specifier, st);
     });
   };
-  base.ImportSpecifier = function (node, st, c) {
-    if (node.name) c(node.name, st, 'Identifier');
-    else c(node.id, st, 'Identifier');
-  };
-  base.ImportBatchSpecifier = function (node, st, c) {
-    c(node.name, st, 'Identifier');
-  };
-  base.Identifier = base.Literal = ignore;
+  base.ImportSpecifier = base.ImportBatchSpecifier = base.Identifier = base.Literal = ignore;
 
   base.TaggedTemplateExpression = function(node, st, c) {
     c(node.tag, st, "Expression");

--- a/util/walk.js
+++ b/util/walk.js
@@ -285,7 +285,23 @@
     c(node.object, st, "Expression");
     if (node.computed) c(node.property, st, "Expression");
   };
-  base.Identifier = base.Literal = base.ExportDeclaration = base.ImportDeclaration = ignore;
+  base.ExportDeclaration = function (node, st, c) {
+    c(node.declaration, st);
+  };
+  base.ImportDeclaration = function (node, st, c) {
+    c(node.source, st, 'Literal');
+    node.specifiers.forEach(function (specifier) {
+      c(specifier, st);
+    });
+  };
+  base.ImportSpecifier = function (node, st, c) {
+    c(node.id, st, 'Identifier');
+    if (node.name) c(node.name, st, 'Identifier');
+  };
+  base.ImportBatchSpecifier = function (node, st, c) {
+    c(node.name, st, 'Identifier');
+  };
+  base.Identifier = base.Literal = ignore;
 
   base.TaggedTemplateExpression = function(node, st, c) {
     c(node.tag, st, "Expression");


### PR DESCRIPTION
This adds support for walking into `ExportDeclaration`s and `ImportDeclaration`s.