### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+/bin/update_authors.sh
+/bin/without_eval
+/test
+/tools
+/.editorconfig
+/.gitattributes
+/.tern-project
+/.travis.yml
+/docco.css


### PR DESCRIPTION
Keeps npm installs light by excluding dev files. The big one here is `/test`, the rest are just for completeness - the install size goes from 2.7M to ~300k.