### PR TITLE
Move parser state into an object, and other rough changes

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -1,9 +1,7 @@
 // Acorn is a tiny, fast JavaScript parser written in JavaScript.
 //
 // Acorn was written by Marijn Haverbeke and various contributors and
-// released under an MIT license. The Unicode regexps (for identifiers
-// and whitespace) were taken from [Esprima](http://esprima.org) by
-// Ariya Hidayat.
+// released under an MIT license.
 //
 // Git repositories for Acorn are available at
 //
@@ -33,19 +31,16 @@
   // The main exported interface (under `self.acorn` when in the
   // browser) is a `parse` function that takes a code string and
   // returns an abstract syntax tree as specified by [Mozilla parser
-  // API][api], with the caveat that inline XML is not recognized.
+  // API][api].
   //
   // [api]: https://developer.mozilla.org/en-US/docs/SpiderMonkey/Parser_API
 
-  var options, input, inputLen, sourceFile;
-
-  exports.parse = function(inpt, opts) {
-    input = String(inpt); inputLen = input.length;
-    setOptions(opts);
-    initTokenState();
-    var startPos = options.locations ? [tokPos, curPosition()] : tokPos;
-    initParserState();
-    return parseTopLevel(options.program || startNodeAt(startPos));
+  exports.parse = function(input, options) {
+    var p = new Parser(options, input);
+    var startPos = p.options.locations ? [p.pos, p.curPosition()] : p.pos;
+    p.skipSpace();
+    p.readToken();
+    return p.parseTopLevel(p.options.program || p.startNodeAt(startPos));
   };
 
   // A second optional argument can be given to further configure
@@ -129,50 +124,12 @@
   // offset in a string. Useful for parsing mixed-language formats
   // that embed JavaScript expressions.
 
-  exports.parseExpressionAt = function(inpt, pos, opts) {
-    input = String(inpt); inputLen = input.length;
-    setOptions(opts);
-    initTokenState(pos);
-    initParserState();
-    return parseExpression();
+  exports.parseExpressionAt = function(input, pos, options) {
+    var p = new Parser(options, input, pos);
+    p.skipSpace();
+    p.readToken();
+    return p.parseExpression();
   };
-
-  var isArray = function (obj) {
-    return Object.prototype.toString.call(obj) === "[object Array]";
-  };
-
-  function setOptions(opts) {
-    options = {};
-    for (var opt in defaultOptions)
-      options[opt] = opts && has(opts, opt) ? opts[opt] : defaultOptions[opt];
-    sourceFile = options.sourceFile || null;
-    if (isArray(options.onToken)) {
-      var tokens = options.onToken;
-      options.onToken = function (token) {
-        tokens.push(token);
-      };
-    }
-    if (isArray(options.onComment)) {
-      var comments = options.onComment;
-      options.onComment = function (block, text, start, end, startLoc, endLoc) {
-        var comment = {
-          type: block ? 'Block' : 'Line',
-          value: text,
-          start: start,
-          end: end
-        };
-        if (options.locations) {
-          comment.loc = new SourceLocation();
-          comment.loc.start = startLoc;
-          comment.loc.end = endLoc;
-        }
-        if (options.ranges)
-          comment.range = [start, end];
-        comments.push(comment);
-      };
-    }
-    isKeyword = options.ecmaVersion >= 6 ? isEcma6Keyword : isEcma5AndLessKeyword;
-  }
 
   // The `getLineInfo` function is mostly useful when the
   // `locations` option is off (for performance reasons) and you
@@ -189,58 +146,61 @@
         cur = match.index + match[0].length;
       } else break;
     }
-    return {line: line, column: offset - cur};
+    return new Position(line, offset - cur);
   };
 
-  function Token() {
-    this.type = tokType;
-    this.value = tokVal;
-    this.start = tokStart;
-    this.end = tokEnd;
-    if (options.locations) {
-      this.loc = new SourceLocation();
-      this.loc.end = tokEndLoc;
-    }
-    if (options.ranges)
-      this.range = [tokStart, tokEnd];
-  }
+  // Object type used to represent tokens. Note that normally, tokens
+  // simply exist as properties on the parser object. This is only
+  // used for the onToken callback and the external tokenizer.
 
-  exports.Token = Token;
+  var Token = exports.Token = function(p) {
+    this.type = p.type;
+    this.value = p.value;
+    this.start = p.start;
+    this.end = p.end;
+    if (p.options.locations) {
+      this.loc = new SourceLocation(p);
+      this.loc.end = p.endLoc;
+    }
+    if (p.options.ranges)
+      this.range = [p.start, p.end];
+  };
 
   // Acorn is organized as a tokenizer and a recursive-descent parser.
   // The `tokenize` export provides an interface to the tokenizer.
   // Because the tokenizer is optimized for being efficiently used by
   // the Acorn parser itself, this interface is somewhat crude and not
-  // very modular. Performing another parse or call to `tokenize` will
-  // reset the internal state, and invalidate existing tokenizers.
+  // very modular.
 
-  exports.tokenize = function(inpt, opts) {
-    input = String(inpt); inputLen = input.length;
-    setOptions(opts);
-    initTokenState();
-    skipSpace();
+  exports.tokenize = function(input, options) {
+    var p = new Parser(options, input);
+    p.skipSpace();
 
     function getToken() {
-      lastEnd = tokEnd;
-      readToken();
-      return new Token();
+      p.lastTokEnd = p.end;
+      p.readToken();
+      return new Token(p);
     }
+
+    getToken.current = function() { return new Token(p); };
+
     getToken.jumpTo = function(pos, exprAllowed) {
-      tokPos = pos;
-      if (options.locations) {
-        tokCurLine = 1;
-        tokLineStart = lineBreak.lastIndex = 0;
+      p.pos = pos;
+      if (p.options.locations) {
+        p.curLine = 1;
+        p.lineStart = lineBreak.lastIndex = 0;
         var match;
-        while ((match = lineBreak.exec(input)) && match.index < pos) {
-          ++tokCurLine;
-          tokLineStart = match.index + match[0].length;
+        while ((match = lineBreak.exec(p.input)) && match.index < pos) {
+          ++p.curLine;
+          p.lineStart = match.index + match[0].length;
         }
       }
-      tokExprAllowed = !!exprAllowed;
-      skipSpace();
+      p.exprAllowed = !!exprAllowed;
+      p.skipSpace();
     };
-    getToken.current = function() { return new Token(); };
-    if (typeof Symbol !== 'undefined') {
+
+    // If we're in an ES6 environment, make this an iterator.
+    if (typeof Symbol !== "undefined") {
       getToken[Symbol.iterator] = function () {
         return {
           next: function () {
@@ -253,86 +213,45 @@
         };
       };
     }
-    getToken.options = options;
+
+    getToken.options = p.options;
     return getToken;
   };
 
-  // State is kept in (closure-)global variables. We already saw the
-  // `options`, `input`, and `inputLen` variables above.
+  // Interpret and default an options object
 
-  // The current position of the tokenizer in the input.
+  function parseOptions(opts) {
+    var options = {};
+    for (var opt in defaultOptions)
+      options[opt] = opts && has(opts, opt) ? opts[opt] : defaultOptions[opt];
 
-  var tokPos;
+    if (isArray(options.onToken)) {
+      var tokens = options.onToken;
+      options.onToken = function (token) { tokens.push(token); };
+    }
+    if (isArray(options.onComment))
+      options.onComment = pushComment(options, options.onComment);
 
-  // The start and end offsets of the current token.
-
-  var tokStart, tokEnd;
-
-  // When `options.locations` is true, these hold objects
-  // containing the tokens start and end line/column pairs.
-
-  var tokStartLoc, tokEndLoc;
-
-  // The type and value of the current token. Token types are objects,
-  // named by variables against which they can be compared, and
-  // holding properties that describe them (indicating, for example,
-  // the precedence of an infix operator, and the original name of a
-  // keyword token). The kind of value that's held in `tokVal` depends
-  // on the type of the token. For literals, it is the literal value,
-  // for operators, the operator name, and so on.
-
-  var tokType, tokVal;
-
-  // Internal state for the tokenizer. To distinguish between division
-  // operators and regular expressions, it remembers whether the last
-  // token was one that is allowed to be followed by an expression. In
-  // some cases, notably after ')' or '}' tokens, the situation
-  // depends on the context before the matching opening bracket, so
-  // tokContext keeps a stack of information about current bracketed
-  // forms.
-
-  var tokContext, tokExprAllowed;
-
-  // When `options.locations` is true, these are used to keep
-  // track of the current line, and know when a new line has been
-  // entered.
-
-  var tokCurLine, tokLineStart;
-
-  // These store the position of the previous token, which is useful
-  // when finishing a node and assigning its `end` position.
-
-  var lastStart, lastEnd, lastEndLoc;
-
-  // This is the parser's state. `inFunction` is used to reject
-  // `return` statements outside of functions, `inGenerator` to
-  // reject `yield`s outside of generators, `labels` to verify
-  // that `break` and `continue` have somewhere to jump to, and
-  // `strict` indicates whether strict mode is on.
-
-  var inFunction, inGenerator, labels, strict;
-
-  function initParserState() {
-    lastStart = lastEnd = tokPos;
-    if (options.locations) lastEndLoc = curPosition();
-    inFunction = inGenerator = false;
-    labels = [];
-    skipSpace();
-    readToken();
+    return options;
   }
 
-  // This function is used to raise exceptions on parse errors. It
-  // takes an offset integer (into the current `input`) to indicate
-  // the location of the error, attaches the position to the end
-  // of the error message, and then raises a `SyntaxError` with that
-  // message.
-
-  function raise(pos, message) {
-    var loc = getLineInfo(input, pos);
-    message += " (" + loc.line + ":" + loc.column + ")";
-    var err = new SyntaxError(message);
-    err.pos = pos; err.loc = loc; err.raisedAt = tokPos;
-    throw err;
+  function pushComment(options, array) {
+    return function (block, text, start, end, startLoc, endLoc) {
+      var comment = {
+        type: block ? 'Block' : 'Line',
+        value: text,
+        start: start,
+        end: end
+      };
+      if (options.locations) {
+        comment.loc = new SourceLocation(this);
+        comment.loc.start = startLoc;
+        comment.loc.end = endLoc;
+      }
+      if (options.ranges)
+        comment.range = [start, end];
+      array.push(comment);
+    };
   }
 
   // Reused empty array added for node fields that are always empty.
@@ -533,8 +452,6 @@
 
   var isEcma6Keyword = makePredicate(ecma5AndLessKeywords + " let const class extends export import yield");
 
-  var isKeyword = isEcma5AndLessKeyword;
-
   // ## Character categories
 
   // Big ugly regular expressions that match characters in the
@@ -587,7 +504,7 @@
   // ## Tokenizer
 
   // These are used when `options.locations` is on, for the
-  // `tokStartLoc` and `tokEndLoc` properties.
+  // `startLoc` and `endLoc` properties.
 
   function Position(line, col) {
     this.line = line;
@@ -597,682 +514,6 @@
   Position.prototype.offset = function(n) {
     return new Position(this.line, this.column + n);
   };
-
-  function curPosition() {
-    return new Position(tokCurLine, tokPos - tokLineStart);
-  }
-
-  // Reset the token state. Used at the start of a parse.
-
-  function initTokenState(pos) {
-    if (pos) {
-      tokPos = pos;
-      tokLineStart = Math.max(0, input.lastIndexOf("\n", pos));
-      tokCurLine = input.slice(0, tokLineStart).split(newline).length;
-    } else {
-      tokCurLine = 1;
-      tokPos = tokLineStart = 0;
-    }
-    tokType = _eof;
-    tokContext = [b_stat];
-    tokExprAllowed = true;
-    strict = false;
-    if (tokPos === 0 && options.allowHashBang && input.slice(0, 2) === '#!') {
-      skipLineComment(2);
-    }
-  }
-
-  // The algorithm used to determine whether a regexp can appear at a
-  // given point in the program is loosely based on sweet.js' approach.
-  // See https://github.com/mozilla/sweet.js/wiki/design
-
-  var b_stat = {token: "{", isExpr: false}, b_expr = {token: "{", isExpr: true}, b_tmpl = {token: "${", isExpr: true};
-  var p_stat = {token: "(", isExpr: false}, p_expr = {token: "(", isExpr: true};
-  var q_tmpl = {token: "`", isExpr: true}, f_expr = {token: "function", isExpr: true};
-
-  function curTokContext() {
-    return tokContext[tokContext.length - 1];
-  }
-
-  function braceIsBlock(prevType) {
-    var parent;
-    if (prevType === _colon && (parent = curTokContext()).token == "{")
-      return !parent.isExpr;
-    if (prevType === _return)
-      return newline.test(input.slice(lastEnd, tokStart));
-    if (prevType === _else || prevType === _semi || prevType === _eof)
-      return true;
-    if (prevType == _braceL)
-      return curTokContext() === b_stat;
-    return !tokExprAllowed;
-  }
-
-  // Called at the end of every token. Sets `tokEnd`, `tokVal`, and
-  // maintains `tokContext` and `tokExprAllowed`, and skips the space
-  // after the token, so that the next one's `tokStart` will point at
-  // the right position.
-
-  function finishToken(type, val) {
-    tokEnd = tokPos;
-    if (options.locations) tokEndLoc = curPosition();
-    var prevType = tokType, preserveSpace = false;
-    tokType = type;
-    tokVal = val;
-
-    // Update context info
-    if (type === _parenR || type === _braceR) {
-      var out = tokContext.pop();
-      if (out === b_tmpl) {
-        preserveSpace = true;
-      } else if (out === b_stat && curTokContext() === f_expr) {
-        tokContext.pop();
-        tokExprAllowed = false;
-      } else {
-        tokExprAllowed = !(out && out.isExpr);
-      }
-    } else if (type === _braceL) {
-      tokContext.push(braceIsBlock(prevType) ? b_stat : b_expr);
-      tokExprAllowed = true;
-    } else if (type === _dollarBraceL) {
-      tokContext.push(b_tmpl);
-      tokExprAllowed = true;
-    } else if (type == _parenL) {
-      var statementParens = prevType === _if || prevType === _for || prevType === _with || prevType === _while;
-      tokContext.push(statementParens ? p_stat : p_expr);
-      tokExprAllowed = true;
-    } else if (type == _incDec) {
-      // tokExprAllowed stays unchanged
-    } else if (type.keyword && prevType == _dot) {
-      tokExprAllowed = false;
-    } else if (type == _function) {
-      if (curTokContext() !== b_stat) {
-        tokContext.push(f_expr);
-      }
-      tokExprAllowed = false;
-    } else if (type === _backQuote) {
-      if (curTokContext() === q_tmpl) {
-        tokContext.pop();
-      } else {
-        tokContext.push(q_tmpl);
-        preserveSpace = true;
-      }
-      tokExprAllowed = false;
-    } else {
-      tokExprAllowed = type.beforeExpr;
-    }
-
-    if (!preserveSpace) skipSpace();
-  }
-
-  function skipBlockComment() {
-    var startLoc = options.onComment && options.locations && curPosition();
-    var start = tokPos, end = input.indexOf("*/", tokPos += 2);
-    if (end === -1) raise(tokPos - 2, "Unterminated comment");
-    tokPos = end + 2;
-    if (options.locations) {
-      lineBreak.lastIndex = start;
-      var match;
-      while ((match = lineBreak.exec(input)) && match.index < tokPos) {
-        ++tokCurLine;
-        tokLineStart = match.index + match[0].length;
-      }
-    }
-    if (options.onComment)
-      options.onComment(true, input.slice(start + 2, end), start, tokPos,
-                        startLoc, options.locations && curPosition());
-  }
-
-  function skipLineComment(startSkip) {
-    var start = tokPos;
-    var startLoc = options.onComment && options.locations && curPosition();
-    var ch = input.charCodeAt(tokPos+=startSkip);
-    while (tokPos < inputLen && ch !== 10 && ch !== 13 && ch !== 8232 && ch !== 8233) {
-      ++tokPos;
-      ch = input.charCodeAt(tokPos);
-    }
-    if (options.onComment)
-      options.onComment(false, input.slice(start + startSkip, tokPos), start, tokPos,
-                        startLoc, options.locations && curPosition());
-  }
-
-  // Called at the start of the parse and after every token. Skips
-  // whitespace and comments, and.
-
-  function skipSpace() {
-    while (tokPos < inputLen) {
-      var ch = input.charCodeAt(tokPos);
-      if (ch === 32) { // ' '
-        ++tokPos;
-      } else if (ch === 13) {
-        ++tokPos;
-        var next = input.charCodeAt(tokPos);
-        if (next === 10) {
-          ++tokPos;
-        }
-        if (options.locations) {
-          ++tokCurLine;
-          tokLineStart = tokPos;
-        }
-      } else if (ch === 10 || ch === 8232 || ch === 8233) {
-        ++tokPos;
-        if (options.locations) {
-          ++tokCurLine;
-          tokLineStart = tokPos;
-        }
-      } else if (ch > 8 && ch < 14) {
-        ++tokPos;
-      } else if (ch === 47) { // '/'
-        var next = input.charCodeAt(tokPos + 1);
-        if (next === 42) { // '*'
-          skipBlockComment();
-        } else if (next === 47) { // '/'
-          skipLineComment(2);
-        } else break;
-      } else if (ch === 160) { // '\xa0'
-        ++tokPos;
-      } else if (ch >= 5760 && nonASCIIwhitespace.test(String.fromCharCode(ch))) {
-        ++tokPos;
-      } else {
-        break;
-      }
-    }
-  }
-
-  // ### Token reading
-
-  // This is the function that is called to fetch the next token. It
-  // is somewhat obscure, because it works in character codes rather
-  // than characters, and because operator parsing has been inlined
-  // into it.
-  //
-  // All in the name of speed.
-  //
-  function readToken_dot() {
-    var next = input.charCodeAt(tokPos + 1);
-    if (next >= 48 && next <= 57) return readNumber(true);
-    var next2 = input.charCodeAt(tokPos + 2);
-    if (options.ecmaVersion >= 6 && next === 46 && next2 === 46) { // 46 = dot '.'
-      tokPos += 3;
-      return finishToken(_ellipsis);
-    } else {
-      ++tokPos;
-      return finishToken(_dot);
-    }
-  }
-
-  function readToken_slash() { // '/'
-    var next = input.charCodeAt(tokPos + 1);
-    if (tokExprAllowed) {++tokPos; return readRegexp();}
-    if (next === 61) return finishOp(_assign, 2);
-    return finishOp(_slash, 1);
-  }
-
-  function readToken_mult_modulo(code) { // '%*'
-    var next = input.charCodeAt(tokPos + 1);
-    if (next === 61) return finishOp(_assign, 2);
-    return finishOp(code === 42 ? _star : _modulo, 1);
-  }
-
-  function readToken_pipe_amp(code) { // '|&'
-    var next = input.charCodeAt(tokPos + 1);
-    if (next === code) return finishOp(code === 124 ? _logicalOR : _logicalAND, 2);
-    if (next === 61) return finishOp(_assign, 2);
-    return finishOp(code === 124 ? _bitwiseOR : _bitwiseAND, 1);
-  }
-
-  function readToken_caret() { // '^'
-    var next = input.charCodeAt(tokPos + 1);
-    if (next === 61) return finishOp(_assign, 2);
-    return finishOp(_bitwiseXOR, 1);
-  }
-
-  function readToken_plus_min(code) { // '+-'
-    var next = input.charCodeAt(tokPos + 1);
-    if (next === code) {
-      if (next == 45 && input.charCodeAt(tokPos + 2) == 62 &&
-          newline.test(input.slice(lastEnd, tokPos))) {
-        // A `-->` line comment
-        skipLineComment(3);
-        skipSpace();
-        return readToken();
-      }
-      return finishOp(_incDec, 2);
-    }
-    if (next === 61) return finishOp(_assign, 2);
-    return finishOp(_plusMin, 1);
-  }
-
-  function readToken_lt_gt(code) { // '<>'
-    var next = input.charCodeAt(tokPos + 1);
-    var size = 1;
-    if (next === code) {
-      size = code === 62 && input.charCodeAt(tokPos + 2) === 62 ? 3 : 2;
-      if (input.charCodeAt(tokPos + size) === 61) return finishOp(_assign, size + 1);
-      return finishOp(_bitShift, size);
-    }
-    if (next == 33 && code == 60 && input.charCodeAt(tokPos + 2) == 45 &&
-        input.charCodeAt(tokPos + 3) == 45) {
-      // `<!--`, an XML-style comment that should be interpreted as a line comment
-      skipLineComment(4);
-      skipSpace();
-      return readToken();
-    }
-    if (next === 61)
-      size = input.charCodeAt(tokPos + 2) === 61 ? 3 : 2;
-    return finishOp(_relational, size);
-  }
-
-  function readToken_eq_excl(code) { // '=!', '=>'
-    var next = input.charCodeAt(tokPos + 1);
-    if (next === 61) return finishOp(_equality, input.charCodeAt(tokPos + 2) === 61 ? 3 : 2);
-    if (code === 61 && next === 62 && options.ecmaVersion >= 6) { // '=>'
-      tokPos += 2;
-      return finishToken(_arrow);
-    }
-    return finishOp(code === 61 ? _eq : _prefix, 1);
-  }
-
-  function getTokenFromCode(code) {
-    switch (code) {
-    // The interpretation of a dot depends on whether it is followed
-    // by a digit or another two dots.
-    case 46: // '.'
-      return readToken_dot();
-
-    // Punctuation tokens.
-    case 40: ++tokPos; return finishToken(_parenL);
-    case 41: ++tokPos; return finishToken(_parenR);
-    case 59: ++tokPos; return finishToken(_semi);
-    case 44: ++tokPos; return finishToken(_comma);
-    case 91: ++tokPos; return finishToken(_bracketL);
-    case 93: ++tokPos; return finishToken(_bracketR);
-    case 123: ++tokPos; return finishToken(_braceL);
-    case 125: ++tokPos; return finishToken(_braceR);
-    case 58: ++tokPos; return finishToken(_colon);
-    case 63: ++tokPos; return finishToken(_question);
-
-    case 96: // '`'
-      if (options.ecmaVersion >= 6) {
-        ++tokPos;
-        return finishToken(_backQuote);
-      } else {
-        return false;
-      }
-
-    case 48: // '0'
-      var next = input.charCodeAt(tokPos + 1);
-      if (next === 120 || next === 88) return readRadixNumber(16); // '0x', '0X' - hex number
-      if (options.ecmaVersion >= 6) {
-        if (next === 111 || next === 79) return readRadixNumber(8); // '0o', '0O' - octal number
-        if (next === 98 || next === 66) return readRadixNumber(2); // '0b', '0B' - binary number
-      }
-    // Anything else beginning with a digit is an integer, octal
-    // number, or float.
-    case 49: case 50: case 51: case 52: case 53: case 54: case 55: case 56: case 57: // 1-9
-      return readNumber(false);
-
-    // Quotes produce strings.
-    case 34: case 39: // '"', "'"
-      return readString(code);
-
-    // Operators are parsed inline in tiny state machines. '=' (61) is
-    // often referred to. `finishOp` simply skips the amount of
-    // characters it is given as second argument, and returns a token
-    // of the type given by its first argument.
-
-    case 47: // '/'
-      return readToken_slash();
-
-    case 37: case 42: // '%*'
-      return readToken_mult_modulo(code);
-
-    case 124: case 38: // '|&'
-      return readToken_pipe_amp(code);
-
-    case 94: // '^'
-      return readToken_caret();
-
-    case 43: case 45: // '+-'
-      return readToken_plus_min(code);
-
-    case 60: case 62: // '<>'
-      return readToken_lt_gt(code);
-
-    case 61: case 33: // '=!'
-      return readToken_eq_excl(code);
-
-    case 126: // '~'
-      return finishOp(_prefix, 1);
-    }
-
-    return false;
-  }
-
-  function readToken() {
-    tokStart = tokPos;
-    if (options.locations) tokStartLoc = curPosition();
-    if (tokPos >= inputLen) return finishToken(_eof);
-
-    if (curTokContext() === q_tmpl) {
-      return readTmplToken();
-    }
-
-    var code = input.charCodeAt(tokPos);
-
-    // Identifier or keyword. '\uXXXX' sequences are allowed in
-    // identifiers, so '\' also dispatches to that.
-    if (isIdentifierStart(code) || code === 92 /* '\' */) return readWord();
-
-    var tok = getTokenFromCode(code);
-
-    if (tok === false) {
-      // If we are here, we either found a non-ASCII identifier
-      // character, or something that's entirely disallowed.
-      var ch = String.fromCharCode(code);
-      if (ch === "\\" || nonASCIIidentifierStart.test(ch)) return readWord();
-      raise(tokPos, "Unexpected character '" + ch + "'");
-    }
-    return tok;
-  }
-
-  function finishOp(type, size) {
-    var str = input.slice(tokPos, tokPos + size);
-    tokPos += size;
-    finishToken(type, str);
-  }
-
-  var regexpUnicodeSupport = false;
-  try { new RegExp("\uffff", "u"); regexpUnicodeSupport = true; }
-  catch(e) {}
-
-  // Parse a regular expression. Some context-awareness is necessary,
-  // since a '/' inside a '[]' set does not end the expression.
-
-  function readRegexp() {
-    var content = "", escaped, inClass, start = tokPos;
-    for (;;) {
-      if (tokPos >= inputLen) raise(start, "Unterminated regular expression");
-      var ch = input.charAt(tokPos);
-      if (newline.test(ch)) raise(start, "Unterminated regular expression");
-      if (!escaped) {
-        if (ch === "[") inClass = true;
-        else if (ch === "]" && inClass) inClass = false;
-        else if (ch === "/" && !inClass) break;
-        escaped = ch === "\\";
-      } else escaped = false;
-      ++tokPos;
-    }
-    var content = input.slice(start, tokPos);
-    ++tokPos;
-    // Need to use `readWord1` because '\uXXXX' sequences are allowed
-    // here (don't ask).
-    var mods = readWord1();
-    var tmp = content;
-    if (mods) {
-      var validFlags = /^[gmsiy]*$/;
-      if (options.ecmaVersion >= 6) validFlags = /^[gmsiyu]*$/;
-      if (!validFlags.test(mods)) raise(start, "Invalid regular expression flag");
-      if (mods.indexOf('u') >= 0 && !regexpUnicodeSupport) {
-        // Replace each astral symbol and every Unicode code point
-        // escape sequence that represents such a symbol with a single
-        // ASCII symbol to avoid throwing on regular expressions that
-        // are only valid in combination with the `/u` flag.
-        tmp = tmp
-          .replace(/\\u\{([0-9a-fA-F]{5,6})\}/g, "x")
-          .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "x");
-      }
-    }
-    // Detect invalid regular expressions.
-    try {
-      new RegExp(tmp);
-    } catch (e) {
-      if (e instanceof SyntaxError) raise(start, "Error parsing regular expression: " + e.message);
-      raise(e);
-    }
-    // Get a regular expression object for this pattern-flag pair, or `null` in
-    // case the current environment doesn't support the flags it uses.
-    try {
-      var value = new RegExp(content, mods);
-    } catch (err) {
-      value = null;
-    }
-    return finishToken(_regexp, {pattern: content, flags: mods, value: value});
-  }
-
-  // Read an integer in the given radix. Return null if zero digits
-  // were read, the integer value otherwise. When `len` is given, this
-  // will return `null` unless the integer has exactly `len` digits.
-
-  function readInt(radix, len) {
-    var start = tokPos, total = 0;
-    for (var i = 0, e = len == null ? Infinity : len; i < e; ++i) {
-      var code = input.charCodeAt(tokPos), val;
-      if (code >= 97) val = code - 97 + 10; // a
-      else if (code >= 65) val = code - 65 + 10; // A
-      else if (code >= 48 && code <= 57) val = code - 48; // 0-9
-      else val = Infinity;
-      if (val >= radix) break;
-      ++tokPos;
-      total = total * radix + val;
-    }
-    if (tokPos === start || len != null && tokPos - start !== len) return null;
-
-    return total;
-  }
-
-  function readRadixNumber(radix) {
-    tokPos += 2; // 0x
-    var val = readInt(radix);
-    if (val == null) raise(tokStart + 2, "Expected number in radix " + radix);
-    if (isIdentifierStart(input.charCodeAt(tokPos))) raise(tokPos, "Identifier directly after number");
-    return finishToken(_num, val);
-  }
-
-  // Read an integer, octal integer, or floating-point number.
-
-  function readNumber(startsWithDot) {
-    var start = tokPos, isFloat = false, octal = input.charCodeAt(tokPos) === 48;
-    if (!startsWithDot && readInt(10) === null) raise(start, "Invalid number");
-    if (input.charCodeAt(tokPos) === 46) {
-      ++tokPos;
-      readInt(10);
-      isFloat = true;
-    }
-    var next = input.charCodeAt(tokPos);
-    if (next === 69 || next === 101) { // 'eE'
-      next = input.charCodeAt(++tokPos);
-      if (next === 43 || next === 45) ++tokPos; // '+-'
-      if (readInt(10) === null) raise(start, "Invalid number");
-      isFloat = true;
-    }
-    if (isIdentifierStart(input.charCodeAt(tokPos))) raise(tokPos, "Identifier directly after number");
-
-    var str = input.slice(start, tokPos), val;
-    if (isFloat) val = parseFloat(str);
-    else if (!octal || str.length === 1) val = parseInt(str, 10);
-    else if (/[89]/.test(str) || strict) raise(start, "Invalid number");
-    else val = parseInt(str, 8);
-    return finishToken(_num, val);
-  }
-
-  // Read a string value, interpreting backslash-escapes.
-
-  function readCodePoint() {
-    var ch = input.charCodeAt(tokPos), code;
-
-    if (ch === 123) {
-      if (options.ecmaVersion < 6) unexpected();
-      ++tokPos;
-      code = readHexChar(input.indexOf('}', tokPos) - tokPos);
-      ++tokPos;
-      if (code > 0x10FFFF) unexpected();
-    } else {
-      code = readHexChar(4);
-    }
-
-    // UTF-16 Encoding
-    if (code <= 0xFFFF) {
-      return String.fromCharCode(code);
-    }
-    var cu1 = ((code - 0x10000) >> 10) + 0xD800;
-    var cu2 = ((code - 0x10000) & 1023) + 0xDC00;
-    return String.fromCharCode(cu1, cu2);
-  }
-
-  function readString(quote) {
-    var out = "", chunkStart = ++tokPos;
-    for (;;) {
-      if (tokPos >= inputLen) raise(tokStart, "Unterminated string constant");
-      var ch = input.charCodeAt(tokPos);
-      if (ch === quote) break;
-      if (ch === 92) { // '\'
-        out += input.slice(chunkStart, tokPos);
-        out += readEscapedChar();
-        chunkStart = tokPos;
-      } else {
-        if (isNewLine(ch)) raise(tokStart, "Unterminated string constant");
-        ++tokPos;
-      }
-    }
-    out += input.slice(chunkStart, tokPos++);
-    return finishToken(_string, out);
-  }
-
-  // Reads template string tokens.
-
-  function readTmplToken() {
-    var out = "", chunkStart = tokPos;
-    for (;;) {
-      if (tokPos >= inputLen) raise(tokStart, "Unterminated template");
-      var ch = input.charCodeAt(tokPos);
-      if (ch === 96 || ch === 36 && input.charCodeAt(tokPos + 1) === 123) { // '`', '${'
-        if (tokPos === tokStart && tokType === _template) {
-          if (ch === 36) {
-            tokPos += 2;
-            return finishToken(_dollarBraceL);
-          } else {
-            ++tokPos;
-            return finishToken(_backQuote);
-          }
-        }
-        out += input.slice(chunkStart, tokPos);
-        return finishToken(_template, out);
-      }
-      if (ch === 92) { // '\'
-        out += input.slice(chunkStart, tokPos);
-        out += readEscapedChar();
-        chunkStart = tokPos;
-      } else if (isNewLine(ch)) {
-        out += input.slice(chunkStart, tokPos);
-        ++tokPos;
-        if (ch === 13 && input.charCodeAt(tokPos) === 10) {
-          ++tokPos;
-          out += "\n";
-        } else {
-          out += String.fromCharCode(ch);
-        }
-        if (options.locations) {
-          ++tokCurLine;
-          tokLineStart = tokPos;
-        }
-        chunkStart = tokPos;
-      } else {
-        ++tokPos;
-      }
-    }
-  }
-
-  // Used to read escaped characters
-
-  function readEscapedChar() {
-    var ch = input.charCodeAt(++tokPos);
-    var octal = /^[0-7]+/.exec(input.slice(tokPos, tokPos + 3));
-    if (octal) octal = octal[0];
-    while (octal && parseInt(octal, 8) > 255) octal = octal.slice(0, -1);
-    if (octal === "0") octal = null;
-    ++tokPos;
-    if (octal) {
-      if (strict) raise(tokPos - 2, "Octal literal in strict mode");
-      tokPos += octal.length - 1;
-      return String.fromCharCode(parseInt(octal, 8));
-    } else {
-      switch (ch) {
-        case 110: return "\n"; // 'n' -> '\n'
-        case 114: return "\r"; // 'r' -> '\r'
-        case 120: return String.fromCharCode(readHexChar(2)); // 'x'
-        case 117: return readCodePoint(); // 'u'
-        case 116: return "\t"; // 't' -> '\t'
-        case 98: return "\b"; // 'b' -> '\b'
-        case 118: return "\u000b"; // 'v' -> '\u000b'
-        case 102: return "\f"; // 'f' -> '\f'
-        case 48: return "\0"; // 0 -> '\0'
-        case 13: if (input.charCodeAt(tokPos) === 10) ++tokPos; // '\r\n'
-        case 10: // ' \n'
-          if (options.locations) { tokLineStart = tokPos; ++tokCurLine; }
-          return "";
-        default: return String.fromCharCode(ch);
-      }
-    }
-  }
-
-  // Used to read character escape sequences ('\x', '\u', '\U').
-
-  function readHexChar(len) {
-    var n = readInt(16, len);
-    if (n === null) raise(tokStart, "Bad character escape sequence");
-    return n;
-  }
-
-  // Used to signal to callers of `readWord1` whether the word
-  // contained any escape sequences. This is needed because words with
-  // escape sequences must not be interpreted as keywords.
-
-  var containsEsc;
-
-  // Read an identifier, and return it as a string. Sets `containsEsc`
-  // to whether the word contained a '\u' escape.
-  //
-  // Incrementally adds only escaped chars, adding other chunks as-is
-  // as a micro-optimization.
-
-  function readWord1() {
-    containsEsc = false;
-    var word = "", first = true, chunkStart = tokPos;
-    while (tokPos < inputLen) {
-      var ch = input.charCodeAt(tokPos);
-      if (isIdentifierChar(ch)) {
-        ++tokPos;
-      } else if (ch === 92) { // "\"
-        containsEsc = true;
-        word += input.slice(chunkStart, tokPos);
-        if (input.charCodeAt(++tokPos) != 117) // "u"
-          raise(tokPos, "Expecting Unicode escape sequence \\uXXXX");
-        ++tokPos;
-        var esc = readHexChar(4);
-        var escStr = String.fromCharCode(esc);
-        if (!escStr) raise(tokPos - 1, "Invalid Unicode escape");
-        if (!(first ? isIdentifierStart(esc) : isIdentifierChar(esc)))
-          raise(tokPos - 4, "Invalid Unicode escape");
-        word += escStr;
-        chunkStart = tokPos;
-      } else {
-        break;
-      }
-      first = false;
-    }
-    return word + input.slice(chunkStart, tokPos);
-  }
-
-  // Read an identifier or keyword token. Will check for reserved
-  // words when necessary.
-
-  function readWord() {
-    var word = readWord1();
-    var type = _name;
-    if (!containsEsc && isKeyword(word))
-      type = keywordTypes[word];
-    return finishToken(type, word);
-  }
 
   // ## Parser
 
@@ -1294,176 +535,892 @@
   //
   // [opp]: http://en.wikipedia.org/wiki/Operator-precedence_parser
 
-  // ### Parser utilities
+  function Parser(options, input, startPos) {
+    this.options = parseOptions(options);
+    this.sourceFile = this.options.sourceFile || null;
+    this.isKeyword = this.options.ecmaVersion >= 6 ? isEcma6Keyword : isEcma5AndLessKeyword;
+    this.input = String(input);
 
-  // Continue to the next token.
+    // Set up token state
 
-  function next() {
-    if (options.onToken)
-      options.onToken(new Token());
+    // The current position of the tokenizer in the input.
+    if (startPos) {
+      this.pos = startPos;
+      this.lineStart = Math.max(0, this.input.lastIndexOf("\n", startPos));
+      this.curLine = this.input.slice(0, this.lineStart).split(newline).length;
+    } else {
+      this.pos = this.lineStart = 0;
+      this.curLine = 1;
+    }
 
-    lastStart = tokStart;
-    lastEnd = tokEnd;
-    lastEndLoc = tokEndLoc;
-    readToken();
+    // Properties of the current token:
+    // Its type
+    this.type = _eof;
+    // For tokens that include more information than their type, the value
+    this.value = null;
+    // Its start and end offset
+    this.start = this.end = this.pos;
+    // And, if locations are used, the {line, column} object
+    // corresponding to those offsets
+    this.startLoc = this.endLoc = null;
+
+    // Position information for the previous token
+    this.lastTokEndLoc = null;
+    this.lastTokStart = this.lastTokEnd = this.pos;
+
+    // The context stack is used to superficially track syntactic
+    // context to predict whether a regular expression is allowed in a
+    // given position.
+    this.context = [b_stat];
+    this.exprAllowed = true;
+
+    // Flags to track whether we are in strict mode, a function, a
+    // generator.
+    this.strict = this.inFunction = this.inGenerator = false;
+    // Labels in scope.
+    this.labels = [];
+
+    // If enabled, skip leading hashbang line.
+    if (this.pos === 0 && this.options.allowHashBang && this.input.slice(0, 2) === '#!')
+      this.skipLineComment(2);
   }
 
-  // Enter strict mode. Re-reads the next number or string to
-  // please pedantic tests ("use strict"; 010; -- should fail).
+  // Shorthand because we are going to be adding a _lot_ of methods to
+  // this.
+  var pp = Parser.prototype;
 
-  function setStrict(strct) {
-    strict = strct;
-    if (tokType !== _num && tokType !== _string) return;
-    tokPos = tokStart;
-    if (options.locations) {
-      while (tokPos < tokLineStart) {
-        tokLineStart = input.lastIndexOf("\n", tokLineStart - 2) + 1;
-        --tokCurLine;
+  // Move to the next token
+
+  pp.next = function() {
+    if (this.options.onToken)
+      this.options.onToken(new Token(this));
+
+    this.lastTokEnd = this.end;
+    this.lastTokStart = this.start;
+    this.lastTokEndLoc = this.endLoc;
+    this.readToken();
+  };
+
+  // Toggle strict mode. Re-reads the next number or string to please
+  // pedantic tests (`"use strict"; 010;` should fail).
+
+  pp.setStrict = function(strict) {
+    this.strict = strict;
+    if (this.type !== _num && this.type !== _string) return;
+    this.pos = this.start;
+    if (this.options.locations) {
+      while (this.pos < this.lineStart) {
+        this.lineStart = this.input.lastIndexOf("\n", this.lineStart - 2) + 1;
+        --this.curLine;
       }
     }
-    skipSpace();
-    readToken();
-  }
+    this.skipSpace();
+    this.readToken();
+  };
+
+  pp.curTokContext = function() {
+    return this.context[this.context.length - 1];
+  };
+
+  // Read a single token, updating the parser object's token-related
+  // properties.
+
+  pp.readToken = function() {
+    this.start = this.pos;
+    if (this.options.locations) this.startLoc = this.curPosition();
+    if (this.pos >= this.input.length) return this.finishToken(_eof);
+
+    if (this.curTokContext() === q_tmpl)
+      return this.readTmplToken();
+
+    var code = this.input.charCodeAt(this.pos);
+
+    // Identifier or keyword. '\uXXXX' sequences are allowed in
+    // identifiers, so '\' also dispatches to that.
+    if (isIdentifierStart(code) || code === 92 /* '\' */) return this.readWord();
+
+    if (this.getTokenFromCode(code) === false) {
+      // If we are here, we either found a non-ASCII identifier
+      // character, or something that's entirely disallowed.
+      var ch = String.fromCharCode(code);
+      if (ch === "\\" || nonASCIIidentifierStart.test(ch)) return this.readWord();
+      this.raise(this.pos, "Unexpected character '" + ch + "'");
+    }
+  };
+
+  pp.skipBlockComment = function() {
+    var startLoc = this.options.onComment && this.options.locations && this.curPosition();
+    var start = this.pos, end = this.input.indexOf("*/", this.pos += 2);
+    if (end === -1) this.raise(this.pos - 2, "Unterminated comment");
+    this.pos = end + 2;
+    if (this.options.locations) {
+      lineBreak.lastIndex = start;
+      var match;
+      while ((match = lineBreak.exec(this.input)) && match.index < this.pos) {
+        ++this.curLine;
+        this.lineStart = match.index + match[0].length;
+      }
+    }
+    if (this.options.onComment)
+      this.options.onComment(true, this.input.slice(start + 2, end), start, this.pos,
+                             startLoc, this.options.locations && this.curPosition());
+  };
+
+  pp.skipLineComment = function(startSkip) {
+    var start = this.pos;
+    var startLoc = this.options.onComment && this.options.locations && this.curPosition();
+    var ch = this.input.charCodeAt(this.pos+=startSkip);
+    while (this.pos < this.input.length && ch !== 10 && ch !== 13 && ch !== 8232 && ch !== 8233) {
+      ++this.pos;
+      ch = this.input.charCodeAt(this.pos);
+    }
+    if (this.options.onComment)
+      this.options.onComment(false, this.input.slice(start + startSkip, this.pos), start, this.pos,
+                             startLoc, this.options.locations && this.curPosition());
+  };
+
+  // Called at the start of the parse and after every token. Skips
+  // whitespace and comments, and.
+
+  pp.skipSpace = function() {
+    while (this.pos < this.input.length) {
+      var ch = this.input.charCodeAt(this.pos);
+      if (ch === 32) { // ' '
+        ++this.pos;
+      } else if (ch === 13) {
+        ++this.pos;
+        var next = this.input.charCodeAt(this.pos);
+        if (next === 10) {
+          ++this.pos;
+        }
+        if (this.options.locations) {
+          ++this.curLine;
+          this.lineStart = this.pos;
+        }
+      } else if (ch === 10 || ch === 8232 || ch === 8233) {
+        ++this.pos;
+        if (this.options.locations) {
+          ++this.curLine;
+          this.lineStart = this.pos;
+        }
+      } else if (ch > 8 && ch < 14) {
+        ++this.pos;
+      } else if (ch === 47) { // '/'
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === 42) { // '*'
+          this.skipBlockComment();
+        } else if (next === 47) { // '/'
+          this.skipLineComment(2);
+        } else break;
+      } else if (ch === 160) { // '\xa0'
+        ++this.pos;
+      } else if (ch >= 5760 && nonASCIIwhitespace.test(String.fromCharCode(ch))) {
+        ++this.pos;
+      } else {
+        break;
+      }
+    }
+  };
+
+  pp.curPosition = function() {
+    return new Position(this.curLine, this.pos - this.lineStart);
+  };
+
+  // The algorithm used to determine whether a regexp can appear at a
+  // given point in the program is loosely based on sweet.js' approach.
+  // See https://github.com/mozilla/sweet.js/wiki/design
+
+  var b_stat = {token: "{", isExpr: false}, b_expr = {token: "{", isExpr: true}, b_tmpl = {token: "${", isExpr: true};
+  var p_stat = {token: "(", isExpr: false}, p_expr = {token: "(", isExpr: true};
+  var q_tmpl = {token: "`", isExpr: true}, f_expr = {token: "function", isExpr: true};
+
+  pp.braceIsBlock = function(prevType) {
+    var parent;
+    if (prevType === _colon && (parent = this.curTokContext()).token == "{")
+      return !parent.isExpr;
+    if (prevType === _return)
+      return newline.test(this.input.slice(this.lastTokEnd, this.start));
+    if (prevType === _else || prevType === _semi || prevType === _eof)
+      return true;
+    if (prevType == _braceL)
+      return this.curTokContext() === b_stat;
+    return !this.exprAllowed;
+  };
+
+  // Called at the end of every token. Sets `end`, `val`, and
+  // maintains `context` and `exprAllowed`, and skips the space after
+  // the token, so that the next one's `start` will point at the
+  // right position.
+
+  pp.finishToken = function(type, val) {
+    this.end = this.pos;
+    if (this.options.locations) this.endLoc = this.curPosition();
+    var prevType = this.type, preserveSpace = false;
+    this.type = type;
+    this.value = val;
+
+    // Update context info
+    if (type === _parenR || type === _braceR) {
+      var out = this.context.pop();
+      if (out === b_tmpl) {
+        preserveSpace = true;
+      } else if (out === b_stat && this.curTokContext() === f_expr) {
+        this.context.pop();
+        this.exprAllowed = false;
+      } else {
+        this.exprAllowed = !(out && out.isExpr);
+      }
+    } else if (type === _braceL) {
+      this.context.push(this.braceIsBlock(prevType) ? b_stat : b_expr);
+      this.exprAllowed = true;
+    } else if (type === _dollarBraceL) {
+      this.context.push(b_tmpl);
+      this.exprAllowed = true;
+    } else if (type == _parenL) {
+      var statementParens = prevType === _if || prevType === _for || prevType === _with || prevType === _while;
+      this.context.push(statementParens ? p_stat : p_expr);
+      this.exprAllowed = true;
+    } else if (type == _incDec) {
+      // tokExprAllowed stays unchanged
+    } else if (type.keyword && prevType == _dot) {
+      this.exprAllowed = false;
+    } else if (type == _function) {
+      if (this.curTokContext() !== b_stat) {
+        this.context.push(f_expr);
+      }
+      this.exprAllowed = false;
+    } else if (type === _backQuote) {
+      if (this.curTokContext() === q_tmpl) {
+        this.context.pop();
+      } else {
+        this.context.push(q_tmpl);
+        preserveSpace = true;
+      }
+      this.exprAllowed = false;
+    } else {
+      this.exprAllowed = type.beforeExpr;
+    }
+
+    if (!preserveSpace) this.skipSpace();
+  };
+
+  // ### Token reading
+
+  // This is the function that is called to fetch the next token. It
+  // is somewhat obscure, because it works in character codes rather
+  // than characters, and because operator parsing has been inlined
+  // into it.
+  //
+  // All in the name of speed.
+  //
+  pp.readToken_dot = function() {
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next >= 48 && next <= 57) return this.readNumber(true);
+    var next2 = this.input.charCodeAt(this.pos + 2);
+    if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) { // 46 = dot '.'
+      this.pos += 3;
+      return this.finishToken(_ellipsis);
+    } else {
+      ++this.pos;
+      return this.finishToken(_dot);
+    }
+  };
+
+  pp.readToken_slash = function() { // '/'
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (this.exprAllowed) {++this.pos; return this.readRegexp();}
+    if (next === 61) return this.finishOp(_assign, 2);
+    return this.finishOp(_slash, 1);
+  };
+
+  pp.readToken_mult_modulo = function(code) { // '%*'
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === 61) return this.finishOp(_assign, 2);
+    return this.finishOp(code === 42 ? _star : _modulo, 1);
+  };
+
+  pp.readToken_pipe_amp = function(code) { // '|&'
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === code) return this.finishOp(code === 124 ? _logicalOR : _logicalAND, 2);
+    if (next === 61) return this.finishOp(_assign, 2);
+    return this.finishOp(code === 124 ? _bitwiseOR : _bitwiseAND, 1);
+  };
+
+  pp.readToken_caret = function() { // '^'
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === 61) return this.finishOp(_assign, 2);
+    return this.finishOp(_bitwiseXOR, 1);
+  };
+
+  pp.readToken_plus_min = function(code) { // '+-'
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === code) {
+      if (next == 45 && this.input.charCodeAt(this.pos + 2) == 62 &&
+          newline.test(this.input.slice(this.lastTokEnd, this.pos))) {
+        // A `-->` line comment
+        this.skipLineComment(3);
+        this.skipSpace();
+        return this.readToken();
+      }
+      return this.finishOp(_incDec, 2);
+    }
+    if (next === 61) return this.finishOp(_assign, 2);
+    return this.finishOp(_plusMin, 1);
+  };
+
+  pp.readToken_lt_gt = function(code) { // '<>'
+    var next = this.input.charCodeAt(this.pos + 1);
+    var size = 1;
+    if (next === code) {
+      size = code === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+      if (this.input.charCodeAt(this.pos + size) === 61) return this.finishOp(_assign, size + 1);
+      return this.finishOp(_bitShift, size);
+    }
+    if (next == 33 && code == 60 && this.input.charCodeAt(this.pos + 2) == 45 &&
+        this.input.charCodeAt(this.pos + 3) == 45) {
+      // `<!--`, an XML-style comment that should be interpreted as a line comment
+      this.skipLineComment(4);
+      this.skipSpace();
+      return this.readToken();
+    }
+    if (next === 61)
+      size = this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2;
+    return this.finishOp(_relational, size);
+  };
+
+  pp.readToken_eq_excl = function(code) { // '=!', '=>'
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === 61) return this.finishOp(_equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+    if (code === 61 && next === 62 && this.options.ecmaVersion >= 6) { // '=>'
+      this.pos += 2;
+      return this.finishToken(_arrow);
+    }
+    return this.finishOp(code === 61 ? _eq : _prefix, 1);
+  };
+
+  pp.getTokenFromCode = function(code) {
+    switch (code) {
+    // The interpretation of a dot depends on whether it is followed
+    // by a digit or another two dots.
+    case 46: // '.'
+      return this.readToken_dot();
+
+    // Punctuation tokens.
+    case 40: ++this.pos; return this.finishToken(_parenL);
+    case 41: ++this.pos; return this.finishToken(_parenR);
+    case 59: ++this.pos; return this.finishToken(_semi);
+    case 44: ++this.pos; return this.finishToken(_comma);
+    case 91: ++this.pos; return this.finishToken(_bracketL);
+    case 93: ++this.pos; return this.finishToken(_bracketR);
+    case 123: ++this.pos; return this.finishToken(_braceL);
+    case 125: ++this.pos; return this.finishToken(_braceR);
+    case 58: ++this.pos; return this.finishToken(_colon);
+    case 63: ++this.pos; return this.finishToken(_question);
+
+    case 96: // '`'
+      if (this.options.ecmaVersion >= 6) {
+        ++this.pos;
+        return this.finishToken(_backQuote);
+      } else {
+        return false;
+      }
+
+    case 48: // '0'
+      var next = this.input.charCodeAt(this.pos + 1);
+      if (next === 120 || next === 88) return this.readRadixNumber(16); // '0x', '0X' - hex number
+      if (this.options.ecmaVersion >= 6) {
+        if (next === 111 || next === 79) return this.readRadixNumber(8); // '0o', '0O' - octal number
+        if (next === 98 || next === 66) return this.readRadixNumber(2); // '0b', '0B' - binary number
+      }
+    // Anything else beginning with a digit is an integer, octal
+    // number, or float.
+    case 49: case 50: case 51: case 52: case 53: case 54: case 55: case 56: case 57: // 1-9
+      return this.readNumber(false);
+
+    // Quotes produce strings.
+    case 34: case 39: // '"', "'"
+      return this.readString(code);
+
+    // Operators are parsed inline in tiny state machines. '=' (61) is
+    // often referred to. `finishOp` simply skips the amount of
+    // characters it is given as second argument, and returns a token
+    // of the type given by its first argument.
+
+    case 47: // '/'
+      return this.readToken_slash();
+
+    case 37: case 42: // '%*'
+      return this.readToken_mult_modulo(code);
+
+    case 124: case 38: // '|&'
+      return this.readToken_pipe_amp(code);
+
+    case 94: // '^'
+      return this.readToken_caret();
+
+    case 43: case 45: // '+-'
+      return this.readToken_plus_min(code);
+
+    case 60: case 62: // '<>'
+      return this.readToken_lt_gt(code);
+
+    case 61: case 33: // '=!'
+      return this.readToken_eq_excl(code);
+
+    case 126: // '~'
+      return this.finishOp(_prefix, 1);
+    }
+
+    return false;
+  };
+
+  pp.finishOp = function(type, size) {
+    var str = this.input.slice(this.pos, this.pos + size);
+    this.pos += size;
+    return this.finishToken(type, str);
+  };
+
+  var regexpUnicodeSupport = false;
+  try { new RegExp("\uffff", "u"); regexpUnicodeSupport = true; }
+  catch(e) {}
+
+  // Parse a regular expression. Some context-awareness is necessary,
+  // since a '/' inside a '[]' set does not end the expression.
+
+  pp.readRegexp = function() {
+    var content = "", escaped, inClass, start = this.pos;
+    for (;;) {
+      if (this.pos >= this.input.length) this.raise(start, "Unterminated regular expression");
+      var ch = this.input.charAt(this.pos);
+      if (newline.test(ch)) this.raise(start, "Unterminated regular expression");
+      if (!escaped) {
+        if (ch === "[") inClass = true;
+        else if (ch === "]" && inClass) inClass = false;
+        else if (ch === "/" && !inClass) break;
+        escaped = ch === "\\";
+      } else escaped = false;
+      ++this.pos;
+    }
+    var content = this.input.slice(start, this.pos);
+    ++this.pos;
+    // Need to use `readWord1` because '\uXXXX' sequences are allowed
+    // here (don't ask).
+    var mods = this.readWord1();
+    var tmp = content;
+    if (mods) {
+      var validFlags = /^[gmsiy]*$/;
+      if (this.options.ecmaVersion >= 6) validFlags = /^[gmsiyu]*$/;
+      if (!validFlags.test(mods)) this.raise(start, "Invalid regular expression flag");
+      if (mods.indexOf('u') >= 0 && !regexpUnicodeSupport) {
+        // Replace each astral symbol and every Unicode code point
+        // escape sequence that represents such a symbol with a single
+        // ASCII symbol to avoid throwing on regular expressions that
+        // are only valid in combination with the `/u` flag.
+        tmp = tmp
+          .replace(/\\u\{([0-9a-fA-F]{5,6})\}/g, "x")
+          .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "x");
+      }
+    }
+    // Detect invalid regular expressions.
+    try {
+      new RegExp(tmp);
+    } catch (e) {
+      if (e instanceof SyntaxError) this.raise(start, "Error parsing regular expression: " + e.message);
+      this.raise(e);
+    }
+    // Get a regular expression object for this pattern-flag pair, or `null` in
+    // case the current environment doesn't support the flags it uses.
+    try {
+      var value = new RegExp(content, mods);
+    } catch (err) {
+      value = null;
+    }
+    return this.finishToken(_regexp, {pattern: content, flags: mods, value: value});
+  };
+
+  // Read an integer in the given radix. Return null if zero digits
+  // were read, the integer value otherwise. When `len` is given, this
+  // will return `null` unless the integer has exactly `len` digits.
+
+  pp.readInt = function(radix, len) {
+    var start = this.pos, total = 0;
+    for (var i = 0, e = len == null ? Infinity : len; i < e; ++i) {
+      var code = this.input.charCodeAt(this.pos), val;
+      if (code >= 97) val = code - 97 + 10; // a
+      else if (code >= 65) val = code - 65 + 10; // A
+      else if (code >= 48 && code <= 57) val = code - 48; // 0-9
+      else val = Infinity;
+      if (val >= radix) break;
+      ++this.pos;
+      total = total * radix + val;
+    }
+    if (this.pos === start || len != null && this.pos - start !== len) return null;
+
+    return total;
+  };
+
+  pp.readRadixNumber = function(radix) {
+    this.pos += 2; // 0x
+    var val = this.readInt(radix);
+    if (val == null) this.raise(this.start + 2, "Expected number in radix " + radix);
+    if (isIdentifierStart(this.input.charCodeAt(this.pos))) this.raise(this.pos, "Identifier directly after number");
+    return this.finishToken(_num, val);
+  };
+
+  // Read an integer, octal integer, or floating-point number.
+
+  pp.readNumber = function(startsWithDot) {
+    var start = this.pos, isFloat = false, octal = this.input.charCodeAt(this.pos) === 48;
+    if (!startsWithDot && this.readInt(10) === null) this.raise(start, "Invalid number");
+    if (this.input.charCodeAt(this.pos) === 46) {
+      ++this.pos;
+      this.readInt(10);
+      isFloat = true;
+    }
+    var next = this.input.charCodeAt(this.pos);
+    if (next === 69 || next === 101) { // 'eE'
+      next = this.input.charCodeAt(++this.pos);
+      if (next === 43 || next === 45) ++this.pos; // '+-'
+      if (this.readInt(10) === null) this.raise(start, "Invalid number");
+      isFloat = true;
+    }
+    if (isIdentifierStart(this.input.charCodeAt(this.pos))) this.raise(this.pos, "Identifier directly after number");
+
+    var str = this.input.slice(start, this.pos), val;
+    if (isFloat) val = parseFloat(str);
+    else if (!octal || str.length === 1) val = parseInt(str, 10);
+    else if (/[89]/.test(str) || this.strict) this.raise(start, "Invalid number");
+    else val = parseInt(str, 8);
+    return this.finishToken(_num, val);
+  };
+
+  // Read a string value, interpreting backslash-escapes.
+
+  pp.readCodePoint = function() {
+    var ch = this.input.charCodeAt(this.pos), code;
+
+    if (ch === 123) {
+      if (this.options.ecmaVersion < 6) this.unexpected();
+      ++this.pos;
+      code = this.readHexChar(this.input.indexOf('}', this.pos) - this.pos);
+      ++this.pos;
+      if (code > 0x10FFFF) this.unexpected();
+    } else {
+      code = this.readHexChar(4);
+    }
+
+    // UTF-16 Encoding
+    if (code <= 0xFFFF) {
+      return String.fromCharCode(code);
+    }
+    var cu1 = ((code - 0x10000) >> 10) + 0xD800;
+    var cu2 = ((code - 0x10000) & 1023) + 0xDC00;
+    return String.fromCharCode(cu1, cu2);
+  };
+
+  pp.readString = function(quote) {
+    var out = "", chunkStart = ++this.pos;
+    for (;;) {
+      if (this.pos >= this.input.length) this.raise(this.start, "Unterminated string constant");
+      var ch = this.input.charCodeAt(this.pos);
+      if (ch === quote) break;
+      if (ch === 92) { // '\'
+        out += this.input.slice(chunkStart, this.pos);
+        out += this.readEscapedChar();
+        chunkStart = this.pos;
+      } else {
+        if (isNewLine(ch)) this.raise(this.start, "Unterminated string constant");
+        ++this.pos;
+      }
+    }
+    out += this.input.slice(chunkStart, this.pos++);
+    return this.finishToken(_string, out);
+  };
+
+  // Reads template string tokens.
+
+  pp.readTmplToken = function() {
+    var out = "", chunkStart = this.pos;
+    for (;;) {
+      if (this.pos >= this.input.length) this.raise(this.start, "Unterminated template");
+      var ch = this.input.charCodeAt(this.pos);
+      if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) { // '`', '${'
+        if (this.pos === this.start && this.type === _template) {
+          if (ch === 36) {
+            this.pos += 2;
+            return this.finishToken(_dollarBraceL);
+          } else {
+            ++this.pos;
+            return this.finishToken(_backQuote);
+          }
+        }
+        out += this.input.slice(chunkStart, this.pos);
+        return this.finishToken(_template, out);
+      }
+      if (ch === 92) { // '\'
+        out += this.input.slice(chunkStart, this.pos);
+        out += this.readEscapedChar();
+        chunkStart = this.pos;
+      } else if (isNewLine(ch)) {
+        out += this.input.slice(chunkStart, this.pos);
+        ++this.pos;
+        if (ch === 13 && this.input.charCodeAt(this.pos) === 10) {
+          ++this.pos;
+          out += "\n";
+        } else {
+          out += String.fromCharCode(ch);
+        }
+        if (this.options.locations) {
+          ++this.curLine;
+          this.lineStart = this.pos;
+        }
+        chunkStart = this.pos;
+      } else {
+        ++this.pos;
+      }
+    }
+  };
+
+  // Used to read escaped characters
+
+  pp.readEscapedChar = function() {
+    var ch = this.input.charCodeAt(++this.pos);
+    var octal = /^[0-7]+/.exec(this.input.slice(this.pos, this.pos + 3));
+    if (octal) octal = octal[0];
+    while (octal && parseInt(octal, 8) > 255) octal = octal.slice(0, -1);
+    if (octal === "0") octal = null;
+    ++this.pos;
+    if (octal) {
+      if (this.strict) this.raise(this.pos - 2, "Octal literal in strict mode");
+      this.pos += octal.length - 1;
+      return String.fromCharCode(parseInt(octal, 8));
+    } else {
+      switch (ch) {
+        case 110: return "\n"; // 'n' -> '\n'
+        case 114: return "\r"; // 'r' -> '\r'
+        case 120: return String.fromCharCode(this.readHexChar(2)); // 'x'
+        case 117: return this.readCodePoint(); // 'u'
+        case 116: return "\t"; // 't' -> '\t'
+        case 98: return "\b"; // 'b' -> '\b'
+        case 118: return "\u000b"; // 'v' -> '\u000b'
+        case 102: return "\f"; // 'f' -> '\f'
+        case 48: return "\0"; // 0 -> '\0'
+        case 13: if (this.input.charCodeAt(this.pos) === 10) ++this.pos; // '\r\n'
+        case 10: // ' \n'
+          if (this.options.locations) { this.lineStart = this.pos; ++this.curLine; }
+          return "";
+        default: return String.fromCharCode(ch);
+      }
+    }
+  };
+
+  // Used to read character escape sequences ('\x', '\u', '\U').
+
+  pp.readHexChar = function(len) {
+    var n = this.readInt(16, len);
+    if (n === null) this.raise(this.start, "Bad character escape sequence");
+    return n;
+  };
+
+  // Used to signal to callers of `readWord1` whether the word
+  // contained any escape sequences. This is needed because words with
+  // escape sequences must not be interpreted as keywords.
+
+  var containsEsc;
+
+  // Read an identifier, and return it as a string. Sets `containsEsc`
+  // to whether the word contained a '\u' escape.
+  //
+  // Incrementally adds only escaped chars, adding other chunks as-is
+  // as a micro-optimization.
+
+  pp.readWord1 = function() {
+    containsEsc = false;
+    var word = "", first = true, chunkStart = this.pos;
+    while (this.pos < this.input.length) {
+      var ch = this.input.charCodeAt(this.pos);
+      if (isIdentifierChar(ch)) {
+        ++this.pos;
+      } else if (ch === 92) { // "\"
+        containsEsc = true;
+        word += this.input.slice(chunkStart, this.pos);
+        if (this.input.charCodeAt(++this.pos) != 117) // "u"
+          this.raise(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+        ++this.pos;
+        var esc = this.readHexChar(4);
+        var escStr = String.fromCharCode(esc);
+        if (!escStr) this.raise(this.pos - 1, "Invalid Unicode escape");
+        if (!(first ? isIdentifierStart(esc) : isIdentifierChar(esc)))
+          this.raise(this.pos - 4, "Invalid Unicode escape");
+        word += escStr;
+        chunkStart = this.pos;
+      } else {
+        break;
+      }
+      first = false;
+    }
+    return word + this.input.slice(chunkStart, this.pos);
+  };
+
+  // Read an identifier or keyword token. Will check for reserved
+  // words when necessary.
+
+  pp.readWord = function() {
+    var word = this.readWord1();
+    var type = _name;
+    if (!containsEsc && this.isKeyword(word))
+      type = keywordTypes[word];
+    return this.finishToken(type, word);
+  };
+
+  // This function is used to raise exceptions on parse errors. It
+  // takes an offset integer (into the current `input`) to indicate
+  // the location of the error, attaches the position to the end
+  // of the error message, and then raises a `SyntaxError` with that
+  // message.
+
+  pp.raise = function(pos, message) {
+    var loc = getLineInfo(this.input, pos);
+    message += " (" + loc.line + ":" + loc.column + ")";
+    var err = new SyntaxError(message);
+    err.pos = pos; err.loc = loc; err.raisedAt = this.pos;
+    throw err;
+  };
+
+  pp.currentPos = function() {
+    return this.options.locations ? [this.start, this.startLoc] : this.start;
+  };
+
+  // ### Parser utilities
 
   // Start an AST node, attaching a start offset.
 
-  function Node() {
-    this.type = null;
-    this.start = tokStart;
-    this.end = null;
+  var Node = exports.Node = function() {};
+
+  function SourceLocation(p) {
+    this.start = p.startLoc;
+    if (p.sourceFile !== null) this.source = p.sourceFile;
   }
 
-  exports.Node = Node;
-
-  function SourceLocation() {
-    this.start = tokStartLoc;
-    this.end = null;
-    if (sourceFile !== null) this.source = sourceFile;
-  }
-
-  function startNode() {
-    var node = new Node();
-    if (options.locations)
-      node.loc = new SourceLocation();
-    if (options.directSourceFile)
-      node.sourceFile = options.directSourceFile;
-    if (options.ranges)
-      node.range = [tokStart, 0];
+  pp.startNode = function() {
+    var node = new Node;
+    node.start = this.start;
+    if (this.options.locations)
+      node.loc = new SourceLocation(this);
+    if (this.options.directSourceFile)
+      node.sourceFile = this.options.directSourceFile;
+    if (this.options.ranges)
+      node.range = [this.start, 0];
     return node;
-  }
+  };
 
-  // Sometimes, a node is only started *after* the token stream passed
-  // its start position. The functions below help storing a position
-  // and creating a node from a previous position.
-
-  function storeCurrentPos() {
-    return options.locations ? [tokStart, tokStartLoc] : tokStart;
-  }
-
-  function startNodeAt(pos) {
-    var node = new Node(), start = pos;
-    if (options.locations) {
-      node.loc = new SourceLocation();
+  pp.startNodeAt = function(pos) {
+    var node = new Node, start = pos;
+    if (this.options.locations) {
+      node.loc = new SourceLocation(this);
       node.loc.start = start[1];
       start = pos[0];
     }
     node.start = start;
-    if (options.directSourceFile)
-      node.sourceFile = options.directSourceFile;
-    if (options.ranges)
+    if (this.options.directSourceFile)
+      node.sourceFile = this.options.directSourceFile;
+    if (this.options.ranges)
       node.range = [start, 0];
-
     return node;
-  }
+  };
 
   // Finish an AST node, adding `type` and `end` properties.
 
-  function finishNode(node, type) {
+  pp.finishNode = function(node, type) {
     node.type = type;
-    node.end = lastEnd;
-    if (options.locations)
-      node.loc.end = lastEndLoc;
-    if (options.ranges)
-      node.range[1] = lastEnd;
+    node.end = this.lastTokEnd;
+    if (this.options.locations)
+      node.loc.end = this.lastTokEndLoc;
+    if (this.options.ranges)
+      node.range[1] = this.lastTokEnd;
     return node;
-  }
+  };
 
   // Finish node at given position
 
-  function finishNodeAt(node, type, pos) {
-    if (options.locations) { node.loc.end = pos[1]; pos = pos[0]; }
+  pp.finishNodeAt = function(node, type, pos) {
+    if (this.options.locations) { node.loc.end = pos[1]; pos = pos[0]; }
     node.type = type;
     node.end = pos;
-    if (options.ranges)
+    if (this.options.ranges)
       node.range[1] = pos;
     return node;
-  }
+  };
 
   // Test whether a statement node is the string literal `"use strict"`.
 
-  function isUseStrict(stmt) {
-    return options.ecmaVersion >= 5 && stmt.type === "ExpressionStatement" &&
+  pp.isUseStrict = function(stmt) {
+    return this.options.ecmaVersion >= 5 && stmt.type === "ExpressionStatement" &&
       stmt.expression.type === "Literal" && stmt.expression.value === "use strict";
-  }
+  };
 
   // Predicate that tests whether the next token is of the given
   // type, and if yes, consumes it as a side effect.
 
-  function eat(type) {
-    if (tokType === type) {
-      next();
+  pp.eat = function(type) {
+    if (this.type === type) {
+      this.next();
       return true;
     } else {
       return false;
     }
-  }
+  };
 
   // Tests whether parsed token is a contextual keyword.
 
-  function isContextual(name) {
-    return tokType === _name && tokVal === name;
-  }
+  pp.isContextual = function(name) {
+    return this.type === _name && this.value === name;
+  };
 
   // Consumes contextual keyword if possible.
 
-  function eatContextual(name) {
-    return tokVal === name && eat(_name);
-  }
+  pp.eatContextual = function(name) {
+    return this.value === name && this.eat(_name);
+  };
 
   // Asserts that following token is given contextual keyword.
 
-  function expectContextual(name) {
-    if (!eatContextual(name)) unexpected();
-  }
+  pp.expectContextual = function(name) {
+    if (!this.eatContextual(name)) this.unexpected();
+  };
 
   // Test whether a semicolon can be inserted at the current position.
 
-  function canInsertSemicolon() {
-    return !options.strictSemicolons &&
-      (tokType === _eof || tokType === _braceR || newline.test(input.slice(lastEnd, tokStart)));
-  }
+  pp.canInsertSemicolon = function() {
+    return !this.options.strictSemicolons &&
+      (this.type === _eof || this.type === _braceR || newline.test(this.input.slice(this.lastTokEnd, this.start)));
+  };
 
   // Consume a semicolon, or, failing that, see if we are allowed to
   // pretend that there is a semicolon at this position.
 
-  function semicolon() {
-    if (!eat(_semi) && !canInsertSemicolon()) unexpected();
-  }
+  pp.semicolon = function() {
+    if (!this.eat(_semi) && !this.canInsertSemicolon()) this.unexpected();
+  };
 
   // Expect a token of a given type. If found, consume it, otherwise,
   // raise an unexpected token error.
 
-  function expect(type) {
-    eat(type) || unexpected();
-  }
+  pp.expect = function(type) {
+    this.eat(type) || this.unexpected();
+  };
 
   // Raise an unexpected token error.
 
-  function unexpected(pos) {
-    raise(pos != null ? pos : tokStart, "Unexpected token");
+  pp.unexpected = function(pos) {
+    this.raise(pos != null ? pos : this.start, "Unexpected token");
+  };
+
+  function isArray(obj) {
+    return Object.prototype.toString.call(obj) === "[object Array]";
   }
 
-  // Checks if hash object has a property.
+  // Checks if an object has a property.
 
   function has(obj, propName) {
     return Object.prototype.hasOwnProperty.call(obj, propName);
@@ -1472,8 +1429,8 @@
   // Convert existing expression atom to assignable pattern
   // if possible.
 
-  function toAssignable(node, isBinding) {
-    if (options.ecmaVersion >= 6 && node) {
+  pp.toAssignable = function(node, isBinding) {
+    if (this.options.ecmaVersion >= 6 && node) {
       switch (node.type) {
         case "Identifier":
         case "ObjectPattern":
@@ -1485,21 +1442,21 @@
           node.type = "ObjectPattern";
           for (var i = 0; i < node.properties.length; i++) {
             var prop = node.properties[i];
-            if (prop.kind !== "init") raise(prop.key.start, "Object pattern can't contain getter or setter");
-            toAssignable(prop.value, isBinding);
+            if (prop.kind !== "init") this.raise(prop.key.start, "Object pattern can't contain getter or setter");
+            this.toAssignable(prop.value, isBinding);
           }
           break;
 
         case "ArrayExpression":
           node.type = "ArrayPattern";
-          toAssignableList(node.elements, isBinding);
+          this.toAssignableList(node.elements, isBinding);
           break;
 
         case "AssignmentExpression":
           if (node.operator === "=") {
             node.type = "AssignmentPattern";
           } else {
-            raise(node.left.end, "Only '=' operator can be used for specifying default value.");
+            this.raise(node.left.end, "Only '=' operator can be used for specifying default value.");
           }
           break;
 
@@ -1507,18 +1464,18 @@
           if (!isBinding) break;
 
         default:
-          raise(node.start, "Assigning to rvalue");
+          this.raise(node.start, "Assigning to rvalue");
       }
     }
     return node;
-  }
+  };
 
   // Convert list of expression atoms to binding list.
 
-  function toAssignableList(exprList, isBinding) {
+  pp.toAssignableList = function(exprList, isBinding) {
     if (exprList.length) {
       for (var i = 0; i < exprList.length - 1; i++) {
-        toAssignable(exprList[i], isBinding);
+        this.toAssignable(exprList[i], isBinding);
       }
       var last = exprList[exprList.length - 1];
       switch (last.type) {
@@ -1527,119 +1484,119 @@
         case "SpreadElement":
           last.type = "RestElement";
           var arg = last.argument;
-          toAssignable(arg, isBinding);
+          this.toAssignable(arg, isBinding);
           if (arg.type !== "Identifier" && arg.type !== "MemberExpression" && arg.type !== "ArrayPattern")
-            unexpected(arg.start);
+            this.unexpected(arg.start);
           break;
         default:
-          toAssignable(last, isBinding);
+          this.toAssignable(last, isBinding);
       }
     }
     return exprList;
-  }
+  };
 
   // Parses spread element.
 
-  function parseSpread(refShorthandDefaultPos) {
-    var node = startNode();
-    next();
-    node.argument = parseMaybeAssign(refShorthandDefaultPos);
-    return finishNode(node, "SpreadElement");
-  }
+  pp.parseSpread = function(refShorthandDefaultPos) {
+    var node = this.startNode();
+    this.next();
+    node.argument = this.parseMaybeAssign(refShorthandDefaultPos);
+    return this.finishNode(node, "SpreadElement");
+  };
 
-  function parseRest() {
-    var node = startNode();
-    next();
-    node.argument = tokType === _name || tokType === _bracketL ? parseBindingAtom() : unexpected();
-    return finishNode(node, "RestElement");
-  }
+  pp.parseRest = function() {
+    var node = this.startNode();
+    this.next();
+    node.argument = this.type === _name || this.type === _bracketL ? this.parseBindingAtom() : this.unexpected();
+    return this.finishNode(node, "RestElement");
+  };
 
   // Parses lvalue (assignable) atom.
 
-  function parseBindingAtom() {
-    if (options.ecmaVersion < 6) return parseIdent();
-    switch (tokType) {
+  pp.parseBindingAtom = function() {
+    if (this.options.ecmaVersion < 6) return this.parseIdent();
+    switch (this.type) {
       case _name:
-        return parseIdent();
+        return this.parseIdent();
 
       case _bracketL:
-        var node = startNode();
-        next();
-        node.elements = parseBindingList(_bracketR, true);
-        return finishNode(node, "ArrayPattern");
+        var node = this.startNode();
+        this.next();
+        node.elements = this.parseBindingList(_bracketR, true);
+        return this.finishNode(node, "ArrayPattern");
 
       case _braceL:
-        return parseObj(true);
+        return this.parseObj(true);
 
       default:
-        unexpected();
+        this.unexpected();
     }
-  }
+  };
 
-  function parseBindingList(close, allowEmpty) {
+  pp.parseBindingList = function(close, allowEmpty) {
     var elts = [], first = true;
-    while (!eat(close)) {
-      first ? first = false : expect(_comma);
-      if (tokType === _ellipsis) {
-        elts.push(parseRest());
-        expect(close);
+    while (!this.eat(close)) {
+      first ? first = false : this.expect(_comma);
+      if (this.type === _ellipsis) {
+        elts.push(this.parseRest());
+        this.expect(close);
         break;
       }
-      elts.push(allowEmpty && tokType === _comma ? null : parseMaybeDefault());
+      elts.push(allowEmpty && this.type === _comma ? null : this.parseMaybeDefault());
     }
     return elts;
-  }
+  };
 
   // Parses assignment pattern around given atom if possible.
 
-  function parseMaybeDefault(startPos, left) {
-    startPos = startPos || storeCurrentPos();
-    left = left || parseBindingAtom();
-    if (!eat(_eq)) return left;
-    var node = startNodeAt(startPos);
+  pp.parseMaybeDefault = function(startPos, left) {
+    startPos = startPos || this.currentPos();
+    left = left || this.parseBindingAtom();
+    if (!this.eat(_eq)) return left;
+    var node = this.startNodeAt(startPos);
     node.operator = "=";
     node.left = left;
-    node.right = parseMaybeAssign();
-    return finishNode(node, "AssignmentPattern");
-  }
+    node.right = this.parseMaybeAssign();
+    return this.finishNode(node, "AssignmentPattern");
+  };
 
   // Verify that argument names are not repeated, and it does not
   // try to bind the words `eval` or `arguments`.
 
-  function checkFunctionParam(param, nameHash) {
+  pp.checkFunctionParam = function(param, nameHash) {
     switch (param.type) {
       case "Identifier":
         if (isStrictReservedWord(param.name) || isStrictBadIdWord(param.name))
-          raise(param.start, "Defining '" + param.name + "' in strict mode");
+          this.raise(param.start, "Defining '" + param.name + "' in strict mode");
         if (has(nameHash, param.name))
-          raise(param.start, "Argument name clash in strict mode");
+          this.raise(param.start, "Argument name clash in strict mode");
         nameHash[param.name] = true;
         break;
 
       case "ObjectPattern":
         for (var i = 0; i < param.properties.length; i++)
-          checkFunctionParam(param.properties[i].value, nameHash);
+          this.checkFunctionParam(param.properties[i].value, nameHash);
         break;
 
       case "ArrayPattern":
         for (var i = 0; i < param.elements.length; i++) {
           var elem = param.elements[i];
-          if (elem) checkFunctionParam(elem, nameHash);
+          if (elem) this.checkFunctionParam(elem, nameHash);
         }
         break;
 
       case "RestElement":
-        return checkFunctionParam(param.argument, nameHash);
+        return this.checkFunctionParam(param.argument, nameHash);
     }
-  }
+  };
 
   // Check if property name clashes with already added.
   // Object/class getters and setters are not allowed to clash —
   // either with each other or with an init property — and in
   // strict mode, init properties are also not allowed to be repeated.
 
-  function checkPropClash(prop, propHash) {
-    if (options.ecmaVersion >= 6) return;
+  pp.checkPropClash = function(prop, propHash) {
+    if (this.options.ecmaVersion >= 6) return;
     var key = prop.key, name;
     switch (key.type) {
       case "Identifier": name = key.name; break;
@@ -1650,8 +1607,8 @@
     if (has(propHash, name)) {
       other = propHash[name];
       var isGetSet = kind !== "init";
-      if ((strict || isGetSet) && other[kind] || !(isGetSet ^ other.init))
-        raise(key.start, "Redefinition of property");
+      if ((this.strict || isGetSet) && other[kind] || !(isGetSet ^ other.init))
+        this.raise(key.start, "Redefinition of property");
     } else {
       other = propHash[name] = {
         init: false,
@@ -1660,46 +1617,46 @@
       };
     }
     other[kind] = true;
-  }
+  };
 
   // Verify that a node is an lval — something that can be assigned
   // to.
 
-  function checkLVal(expr, isBinding) {
+  pp.checkLVal = function(expr, isBinding) {
     switch (expr.type) {
       case "Identifier":
-        if (strict && (isStrictBadIdWord(expr.name) || isStrictReservedWord(expr.name)))
-          raise(expr.start, (isBinding ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+        if (this.strict && (isStrictBadIdWord(expr.name) || isStrictReservedWord(expr.name)))
+          this.raise(expr.start, (isBinding ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
         break;
 
       case "MemberExpression":
-        if (isBinding) raise(expr.start, "Binding to member expression");
+        if (isBinding) this.raise(expr.start, "Binding to member expression");
         break;
 
       case "ObjectPattern":
         for (var i = 0; i < expr.properties.length; i++)
-          checkLVal(expr.properties[i].value, isBinding);
+          this.checkLVal(expr.properties[i].value, isBinding);
         break;
 
       case "ArrayPattern":
         for (var i = 0; i < expr.elements.length; i++) {
           var elem = expr.elements[i];
-          if (elem) checkLVal(elem, isBinding);
+          if (elem) this.checkLVal(elem, isBinding);
         }
         break;
 
       case "AssignmentPattern":
-        checkLVal(expr.left);
+        this.checkLVal(expr.left);
         break;
 
       case "RestElement":
-        checkLVal(expr.argument);
+        this.checkLVal(expr.argument);
         break;
 
       default:
-        raise(expr.start, "Assigning to rvalue");
+        this.raise(expr.start, "Assigning to rvalue");
     }
-  }
+  };
 
   // ### Statement parsing
 
@@ -1708,19 +1665,19 @@
   // `program` argument.  If present, the statements will be appended
   // to its body instead of creating a new node.
 
-  function parseTopLevel(node) {
+  pp.parseTopLevel = function(node) {
     var first = true;
     if (!node.body) node.body = [];
-    while (tokType !== _eof) {
-      var stmt = parseStatement(true, true);
+    while (this.type !== _eof) {
+      var stmt = this.parseStatement(true, true);
       node.body.push(stmt);
-      if (first && isUseStrict(stmt)) setStrict(true);
+      if (first && this.isUseStrict(stmt)) this.setStrict(true);
       first = false;
     }
 
-    next();
-    return finishNode(node, "Program");
-  }
+    this.next();
+    return this.finishNode(node, "Program");
+  };
 
   var loopLabel = {kind: "loop"}, switchLabel = {kind: "switch"};
 
@@ -1731,40 +1688,40 @@
   // `if (foo) /blah/.exec(foo);`, where looking at the previous token
   // does not help.
 
-  function parseStatement(declaration, topLevel) {
-    var starttype = tokType, node = startNode();
+  pp.parseStatement = function(declaration, topLevel) {
+    var starttype = this.type, node = this.startNode();
 
     // Most types of statements are recognized by the keyword they
     // start with. Many are trivial to parse, some require a bit of
     // complexity.
 
     switch (starttype) {
-    case _break: case _continue: return parseBreakContinueStatement(node, starttype.keyword);
-    case _debugger: return parseDebuggerStatement(node);
-    case _do: return parseDoStatement(node);
-    case _for: return parseForStatement(node);
+    case _break: case _continue: return this.parseBreakContinueStatement(node, starttype.keyword);
+    case _debugger: return this.parseDebuggerStatement(node);
+    case _do: return this.parseDoStatement(node);
+    case _for: return this.parseForStatement(node);
     case _function:
-      if (!declaration && options.ecmaVersion >= 6) unexpected();
-      return parseFunctionStatement(node);
+      if (!declaration && this.options.ecmaVersion >= 6) this.unexpected();
+      return this.parseFunctionStatement(node);
     case _class:
-      if (!declaration) unexpected();
-      return parseClass(node, true);
-    case _if: return parseIfStatement(node);
-    case _return: return parseReturnStatement(node);
-    case _switch: return parseSwitchStatement(node);
-    case _throw: return parseThrowStatement(node);
-    case _try: return parseTryStatement(node);
-    case _let: case _const: if (!declaration) unexpected(); // NOTE: falls through to _var
-    case _var: return parseVarStatement(node, starttype.keyword);
-    case _while: return parseWhileStatement(node);
-    case _with: return parseWithStatement(node);
-    case _braceL: return parseBlock(); // no point creating a function for this
-    case _semi: return parseEmptyStatement(node);
+      if (!declaration) this.unexpected();
+      return this.parseClass(node, true);
+    case _if: return this.parseIfStatement(node);
+    case _return: return this.parseReturnStatement(node);
+    case _switch: return this.parseSwitchStatement(node);
+    case _throw: return this.parseThrowStatement(node);
+    case _try: return this.parseTryStatement(node);
+    case _let: case _const: if (!declaration) this.unexpected(); // NOTE: falls through to _var
+    case _var: return this.parseVarStatement(node, starttype.keyword);
+    case _while: return this.parseWhileStatement(node);
+    case _with: return this.parseWithStatement(node);
+    case _braceL: return this.parseBlock(); // no point creating a function for this
+    case _semi: return this.parseEmptyStatement(node);
     case _export:
     case _import:
-      if (!topLevel && !options.allowImportExportEverywhere)
-        raise(tokStart, "'import' and 'export' may only appear at the top level");
-      return starttype === _import ? parseImport(node) : parseExport(node);
+      if (!topLevel && !this.options.allowImportExportEverywhere)
+        this.raise(this.start, "'import' and 'export' may only appear at the top level");
+      return starttype === _import ? this.parseImport(node) : this.parseExport(node);
 
       // If the statement does not start with a statement keyword or a
       // brace, it's an ExpressionStatement or LabeledStatement. We
@@ -1772,55 +1729,55 @@
       // next token is a colon and the expression was a simple
       // Identifier node, we switch to interpreting it as a label.
     default:
-      var maybeName = tokVal, expr = parseExpression();
-      if (starttype === _name && expr.type === "Identifier" && eat(_colon))
-        return parseLabeledStatement(node, maybeName, expr);
-      else return parseExpressionStatement(node, expr);
+      var maybeName = this.value, expr = this.parseExpression();
+      if (starttype === _name && expr.type === "Identifier" && this.eat(_colon))
+        return this.parseLabeledStatement(node, maybeName, expr);
+      else return this.parseExpressionStatement(node, expr);
     }
-  }
+  };
 
-  function parseBreakContinueStatement(node, keyword) {
+  pp.parseBreakContinueStatement = function(node, keyword) {
     var isBreak = keyword == "break";
-    next();
-    if (eat(_semi) || canInsertSemicolon()) node.label = null;
-    else if (tokType !== _name) unexpected();
+    this.next();
+    if (this.eat(_semi) || this.canInsertSemicolon()) node.label = null;
+    else if (this.type !== _name) this.unexpected();
     else {
-      node.label = parseIdent();
-      semicolon();
+      node.label = this.parseIdent();
+      this.semicolon();
     }
 
     // Verify that there is an actual destination to break or
     // continue to.
-    for (var i = 0; i < labels.length; ++i) {
-      var lab = labels[i];
+    for (var i = 0; i < this.labels.length; ++i) {
+      var lab = this.labels[i];
       if (node.label == null || lab.name === node.label.name) {
         if (lab.kind != null && (isBreak || lab.kind === "loop")) break;
         if (node.label && isBreak) break;
       }
     }
-    if (i === labels.length) raise(node.start, "Unsyntactic " + keyword);
-    return finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
-  }
+    if (i === this.labels.length) this.raise(node.start, "Unsyntactic " + keyword);
+    return this.finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+  };
 
-  function parseDebuggerStatement(node) {
-    next();
-    semicolon();
-    return finishNode(node, "DebuggerStatement");
-  }
+  pp.parseDebuggerStatement = function(node) {
+    this.next();
+    this.semicolon();
+    return this.finishNode(node, "DebuggerStatement");
+  };
 
-  function parseDoStatement(node) {
-    next();
-    labels.push(loopLabel);
-    node.body = parseStatement(false);
-    labels.pop();
-    expect(_while);
-    node.test = parseParenExpression();
-    if (options.ecmaVersion >= 6)
-      eat(_semi);
+  pp.parseDoStatement = function(node) {
+    this.next();
+    this.labels.push(loopLabel);
+    node.body = this.parseStatement(false);
+    this.labels.pop();
+    this.expect(_while);
+    node.test = this.parseParenExpression();
+    if (this.options.ecmaVersion >= 6)
+      this.eat(_semi);
     else
-      semicolon();
-    return finishNode(node, "DoWhileStatement");
-  }
+      this.semicolon();
+    return this.finishNode(node, "DoWhileStatement");
+  };
 
   // Disambiguating between a `for` and a `for`/`in` or `for`/`of`
   // loop is non-trivial. Basically, we have to parse the init `var`
@@ -1830,248 +1787,248 @@
   // part (semicolon immediately after the opening parenthesis), it
   // is a regular `for` loop.
 
-  function parseForStatement(node) {
-    next();
-    labels.push(loopLabel);
-    expect(_parenL);
-    if (tokType === _semi) return parseFor(node, null);
-    if (tokType === _var || tokType === _let) {
-      var init = startNode(), varKind = tokType.keyword, isLet = tokType === _let;
-      next();
-      parseVar(init, true, varKind);
-      finishNode(init, "VariableDeclaration");
-      if ((tokType === _in || (options.ecmaVersion >= 6 && isContextual("of"))) && init.declarations.length === 1 &&
+  pp.parseForStatement = function(node) {
+    this.next();
+    this.labels.push(loopLabel);
+    this.expect(_parenL);
+    if (this.type === _semi) return this.parseFor(node, null);
+    if (this.type === _var || this.type === _let) {
+      var init = this.startNode(), varKind = this.type.keyword, isLet = this.type === _let;
+      this.next();
+      this.parseVar(init, true, varKind);
+      this.finishNode(init, "VariableDeclaration");
+      if ((this.type === _in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) && init.declarations.length === 1 &&
           !(isLet && init.declarations[0].init))
-        return parseForIn(node, init);
-      return parseFor(node, init);
+        return this.parseForIn(node, init);
+      return this.parseFor(node, init);
     }
     var refShorthandDefaultPos = {start: 0};
-    var init = parseExpression(true, refShorthandDefaultPos);
-    if (tokType === _in || (options.ecmaVersion >= 6 && isContextual("of"))) {
-      toAssignable(init);
-      checkLVal(init);
-      return parseForIn(node, init);
+    var init = this.parseExpression(true, refShorthandDefaultPos);
+    if (this.type === _in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+      this.toAssignable(init);
+      this.checkLVal(init);
+      return this.parseForIn(node, init);
     } else if (refShorthandDefaultPos.start) {
-      unexpected(refShorthandDefaultPos.start);
+      this.unexpected(refShorthandDefaultPos.start);
     }
-    return parseFor(node, init);
-  }
+    return this.parseFor(node, init);
+  };
 
-  function parseFunctionStatement(node) {
-    next();
-    return parseFunction(node, true);
-  }
+  pp.parseFunctionStatement = function(node) {
+    this.next();
+    return this.parseFunction(node, true);
+  };
 
-  function parseIfStatement(node) {
-    next();
-    node.test = parseParenExpression();
-    node.consequent = parseStatement(false);
-    node.alternate = eat(_else) ? parseStatement(false) : null;
-    return finishNode(node, "IfStatement");
-  }
+  pp.parseIfStatement = function(node) {
+    this.next();
+    node.test = this.parseParenExpression();
+    node.consequent = this.parseStatement(false);
+    node.alternate = this.eat(_else) ? this.parseStatement(false) : null;
+    return this.finishNode(node, "IfStatement");
+  };
 
-  function parseReturnStatement(node) {
-    if (!inFunction && !options.allowReturnOutsideFunction)
-      raise(tokStart, "'return' outside of function");
-    next();
+  pp.parseReturnStatement = function(node) {
+    if (!this.inFunction && !this.options.allowReturnOutsideFunction)
+      this.raise(this.start, "'return' outside of function");
+    this.next();
 
     // In `return` (and `break`/`continue`), the keywords with
     // optional arguments, we eagerly look for a semicolon or the
     // possibility to insert one.
 
-    if (eat(_semi) || canInsertSemicolon()) node.argument = null;
-    else { node.argument = parseExpression(); semicolon(); }
-    return finishNode(node, "ReturnStatement");
-  }
+    if (this.eat(_semi) || this.canInsertSemicolon()) node.argument = null;
+    else { node.argument = this.parseExpression(); this.semicolon(); }
+    return this.finishNode(node, "ReturnStatement");
+  };
 
-  function parseSwitchStatement(node) {
-    next();
-    node.discriminant = parseParenExpression();
+  pp.parseSwitchStatement = function(node) {
+    this.next();
+    node.discriminant = this.parseParenExpression();
     node.cases = [];
-    expect(_braceL);
-    labels.push(switchLabel);
+    this.expect(_braceL);
+    this.labels.push(switchLabel);
 
     // Statements under must be grouped (by label) in SwitchCase
     // nodes. `cur` is used to keep the node that we are currently
     // adding statements to.
 
-    for (var cur, sawDefault; tokType != _braceR;) {
-      if (tokType === _case || tokType === _default) {
-        var isCase = tokType === _case;
-        if (cur) finishNode(cur, "SwitchCase");
-        node.cases.push(cur = startNode());
+    for (var cur, sawDefault; this.type != _braceR;) {
+      if (this.type === _case || this.type === _default) {
+        var isCase = this.type === _case;
+        if (cur) this.finishNode(cur, "SwitchCase");
+        node.cases.push(cur = this.startNode());
         cur.consequent = [];
-        next();
-        if (isCase) cur.test = parseExpression();
+        this.next();
+        if (isCase) cur.test = this.parseExpression();
         else {
-          if (sawDefault) raise(lastStart, "Multiple default clauses"); sawDefault = true;
+          if (sawDefault) this.raise(this.lastTokStart, "Multiple default clauses"); sawDefault = true;
           cur.test = null;
         }
-        expect(_colon);
+        this.expect(_colon);
       } else {
-        if (!cur) unexpected();
-        cur.consequent.push(parseStatement(true));
+        if (!cur) this.unexpected();
+        cur.consequent.push(this.parseStatement(true));
       }
     }
-    if (cur) finishNode(cur, "SwitchCase");
-    next(); // Closing brace
-    labels.pop();
-    return finishNode(node, "SwitchStatement");
-  }
+    if (cur) this.finishNode(cur, "SwitchCase");
+    this.next(); // Closing brace
+    this.labels.pop();
+    return this.finishNode(node, "SwitchStatement");
+  };
 
-  function parseThrowStatement(node) {
-    next();
-    if (newline.test(input.slice(lastEnd, tokStart)))
-      raise(lastEnd, "Illegal newline after throw");
-    node.argument = parseExpression();
-    semicolon();
-    return finishNode(node, "ThrowStatement");
-  }
+  pp.parseThrowStatement = function(node) {
+    this.next();
+    if (newline.test(this.input.slice(this.lastTokEnd, this.start)))
+      this.raise(this.lastTokEnd, "Illegal newline after throw");
+    node.argument = this.parseExpression();
+    this.semicolon();
+    return this.finishNode(node, "ThrowStatement");
+  };
 
-  function parseTryStatement(node) {
-    next();
-    node.block = parseBlock();
+  pp.parseTryStatement = function(node) {
+    this.next();
+    node.block = this.parseBlock();
     node.handler = null;
-    if (tokType === _catch) {
-      var clause = startNode();
-      next();
-      expect(_parenL);
-      clause.param = parseBindingAtom();
-      checkLVal(clause.param, true);
-      expect(_parenR);
+    if (this.type === _catch) {
+      var clause = this.startNode();
+      this.next();
+      this.expect(_parenL);
+      clause.param = this.parseBindingAtom();
+      this.checkLVal(clause.param, true);
+      this.expect(_parenR);
       clause.guard = null;
-      clause.body = parseBlock();
-      node.handler = finishNode(clause, "CatchClause");
+      clause.body = this.parseBlock();
+      node.handler = this.finishNode(clause, "CatchClause");
     }
     node.guardedHandlers = empty;
-    node.finalizer = eat(_finally) ? parseBlock() : null;
+    node.finalizer = this.eat(_finally) ? this.parseBlock() : null;
     if (!node.handler && !node.finalizer)
-      raise(node.start, "Missing catch or finally clause");
-    return finishNode(node, "TryStatement");
-  }
+      this.raise(node.start, "Missing catch or finally clause");
+    return this.finishNode(node, "TryStatement");
+  };
 
-  function parseVarStatement(node, kind) {
-    next();
-    parseVar(node, false, kind);
-    semicolon();
-    return finishNode(node, "VariableDeclaration");
-  }
+  pp.parseVarStatement = function(node, kind) {
+    this.next();
+    this.parseVar(node, false, kind);
+    this.semicolon();
+    return this.finishNode(node, "VariableDeclaration");
+  };
 
-  function parseWhileStatement(node) {
-    next();
-    node.test = parseParenExpression();
-    labels.push(loopLabel);
-    node.body = parseStatement(false);
-    labels.pop();
-    return finishNode(node, "WhileStatement");
-  }
+  pp.parseWhileStatement = function(node) {
+    this.next();
+    node.test = this.parseParenExpression();
+    this.labels.push(loopLabel);
+    node.body = this.parseStatement(false);
+    this.labels.pop();
+    return this.finishNode(node, "WhileStatement");
+  };
 
-  function parseWithStatement(node) {
-    if (strict) raise(tokStart, "'with' in strict mode");
-    next();
-    node.object = parseParenExpression();
-    node.body = parseStatement(false);
-    return finishNode(node, "WithStatement");
-  }
+  pp.parseWithStatement = function(node) {
+    if (this.strict) this.raise(this.start, "'with' in strict mode");
+    this.next();
+    node.object = this.parseParenExpression();
+    node.body = this.parseStatement(false);
+    return this.finishNode(node, "WithStatement");
+  };
 
-  function parseEmptyStatement(node) {
-    next();
-    return finishNode(node, "EmptyStatement");
-  }
+  pp.parseEmptyStatement = function(node) {
+    this.next();
+    return this.finishNode(node, "EmptyStatement");
+  };
 
-  function parseLabeledStatement(node, maybeName, expr) {
-    for (var i = 0; i < labels.length; ++i)
-      if (labels[i].name === maybeName) raise(expr.start, "Label '" + maybeName + "' is already declared");
-    var kind = tokType.isLoop ? "loop" : tokType === _switch ? "switch" : null;
-    labels.push({name: maybeName, kind: kind});
-    node.body = parseStatement(true);
-    labels.pop();
+  pp.parseLabeledStatement = function(node, maybeName, expr) {
+    for (var i = 0; i < this.labels.length; ++i)
+      if (this.labels[i].name === maybeName) this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+    var kind = this.type.isLoop ? "loop" : this.type === _switch ? "switch" : null;
+    this.labels.push({name: maybeName, kind: kind});
+    node.body = this.parseStatement(true);
+    this.labels.pop();
     node.label = expr;
-    return finishNode(node, "LabeledStatement");
-  }
+    return this.finishNode(node, "LabeledStatement");
+  };
 
-  function parseExpressionStatement(node, expr) {
+  pp.parseExpressionStatement = function(node, expr) {
     node.expression = expr;
-    semicolon();
-    return finishNode(node, "ExpressionStatement");
-  }
+    this.semicolon();
+    return this.finishNode(node, "ExpressionStatement");
+  };
 
   // Used for constructs like `switch` and `if` that insist on
   // parentheses around their expression.
 
-  function parseParenExpression() {
-    expect(_parenL);
-    var val = parseExpression();
-    expect(_parenR);
+  pp.parseParenExpression = function() {
+    this.expect(_parenL);
+    var val = this.parseExpression();
+    this.expect(_parenR);
     return val;
-  }
+  };
 
   // Parse a semicolon-enclosed block of statements, handling `"use
   // strict"` declarations when `allowStrict` is true (used for
   // function bodies).
 
-  function parseBlock(allowStrict) {
-    var node = startNode(), first = true, oldStrict;
+  pp.parseBlock = function(allowStrict) {
+    var node = this.startNode(), first = true, oldStrict;
     node.body = [];
-    expect(_braceL);
-    while (!eat(_braceR)) {
-      var stmt = parseStatement(true);
+    this.expect(_braceL);
+    while (!this.eat(_braceR)) {
+      var stmt = this.parseStatement(true);
       node.body.push(stmt);
-      if (first && allowStrict && isUseStrict(stmt)) {
-        oldStrict = strict;
-        setStrict(strict = true);
+      if (first && allowStrict && this.isUseStrict(stmt)) {
+        oldStrict = this.strict;
+        this.setStrict(this.strict = true);
       }
       first = false;
     }
-    if (oldStrict === false) setStrict(false);
-    return finishNode(node, "BlockStatement");
-  }
+    if (oldStrict === false) this.setStrict(false);
+    return this.finishNode(node, "BlockStatement");
+  };
 
   // Parse a regular `for` loop. The disambiguation code in
   // `parseStatement` will already have parsed the init statement or
   // expression.
 
-  function parseFor(node, init) {
+  pp.parseFor = function(node, init) {
     node.init = init;
-    expect(_semi);
-    node.test = tokType === _semi ? null : parseExpression();
-    expect(_semi);
-    node.update = tokType === _parenR ? null : parseExpression();
-    expect(_parenR);
-    node.body = parseStatement(false);
-    labels.pop();
-    return finishNode(node, "ForStatement");
-  }
+    this.expect(_semi);
+    node.test = this.type === _semi ? null : this.parseExpression();
+    this.expect(_semi);
+    node.update = this.type === _parenR ? null : this.parseExpression();
+    this.expect(_parenR);
+    node.body = this.parseStatement(false);
+    this.labels.pop();
+    return this.finishNode(node, "ForStatement");
+  };
 
   // Parse a `for`/`in` and `for`/`of` loop, which are almost
   // same from parser's perspective.
 
-  function parseForIn(node, init) {
-    var type = tokType === _in ? "ForInStatement" : "ForOfStatement";
-    next();
+  pp.parseForIn = function(node, init) {
+    var type = this.type === _in ? "ForInStatement" : "ForOfStatement";
+    this.next();
     node.left = init;
-    node.right = parseExpression();
-    expect(_parenR);
-    node.body = parseStatement(false);
-    labels.pop();
-    return finishNode(node, type);
-  }
+    node.right = this.parseExpression();
+    this.expect(_parenR);
+    node.body = this.parseStatement(false);
+    this.labels.pop();
+    return this.finishNode(node, type);
+  };
 
   // Parse a list of variable declarations.
 
-  function parseVar(node, noIn, kind) {
+  pp.parseVar = function(node, noIn, kind) {
     node.declarations = [];
     node.kind = kind;
     for (;;) {
-      var decl = startNode();
-      decl.id = parseBindingAtom();
-      checkLVal(decl.id, true);
-      decl.init = eat(_eq) ? parseMaybeAssign(noIn) : (kind === _const.keyword ? unexpected() : null);
-      node.declarations.push(finishNode(decl, "VariableDeclarator"));
-      if (!eat(_comma)) break;
+      var decl = this.startNode();
+      decl.id = this.parseBindingAtom();
+      this.checkLVal(decl.id, true);
+      decl.init = this.eat(_eq) ? this.parseMaybeAssign(noIn) : (kind === _const.keyword ? this.unexpected() : null);
+      node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+      if (!this.eat(_comma)) break;
     }
     return node;
-  }
+  };
 
   // ### Expression parsing
 
@@ -2088,22 +2045,22 @@
   // and object pattern might appear (so it's possible to raise
   // delayed syntax error at correct position).
 
-  function parseExpression(noIn, refShorthandDefaultPos) {
-    var start = storeCurrentPos();
-    var expr = parseMaybeAssign(noIn, refShorthandDefaultPos);
-    if (tokType === _comma) {
-      var node = startNodeAt(start);
+  pp.parseExpression = function(noIn, refShorthandDefaultPos) {
+    var start = this.currentPos();
+    var expr = this.parseMaybeAssign(noIn, refShorthandDefaultPos);
+    if (this.type === _comma) {
+      var node = this.startNodeAt(start);
       node.expressions = [expr];
-      while (eat(_comma)) node.expressions.push(parseMaybeAssign(noIn, refShorthandDefaultPos));
-      return finishNode(node, "SequenceExpression");
+      while (this.eat(_comma)) node.expressions.push(this.parseMaybeAssign(noIn, refShorthandDefaultPos));
+      return this.finishNode(node, "SequenceExpression");
     }
     return expr;
-  }
+  };
 
   // Parse an assignment expression. This includes applications of
   // operators like `+=`.
 
-  function parseMaybeAssign(noIn, refShorthandDefaultPos) {
+  pp.parseMaybeAssign = function(noIn, refShorthandDefaultPos) {
     var failOnShorthandAssign;
     if (!refShorthandDefaultPos) {
       refShorthandDefaultPos = {start: 0};
@@ -2111,48 +2068,48 @@
     } else {
       failOnShorthandAssign = false;
     }
-    var start = storeCurrentPos();
-    var left = parseMaybeConditional(noIn, refShorthandDefaultPos);
-    if (tokType.isAssign) {
-      var node = startNodeAt(start);
-      node.operator = tokVal;
-      node.left = tokType === _eq ? toAssignable(left) : left;
+    var start = this.currentPos();
+    var left = this.parseMaybeConditional(noIn, refShorthandDefaultPos);
+    if (this.type.isAssign) {
+      var node = this.startNodeAt(start);
+      node.operator = this.value;
+      node.left = this.type === _eq ? this.toAssignable(left) : left;
       refShorthandDefaultPos.start = 0; // reset because shorthand default was used correctly
-      checkLVal(left);
-      next();
-      node.right = parseMaybeAssign(noIn);
-      return finishNode(node, "AssignmentExpression");
+      this.checkLVal(left);
+      this.next();
+      node.right = this.parseMaybeAssign(noIn);
+      return this.finishNode(node, "AssignmentExpression");
     } else if (failOnShorthandAssign && refShorthandDefaultPos.start) {
-      unexpected(refShorthandDefaultPos.start);
+      this.unexpected(refShorthandDefaultPos.start);
     }
     return left;
-  }
+  };
 
   // Parse a ternary conditional (`?:`) operator.
 
-  function parseMaybeConditional(noIn, refShorthandDefaultPos) {
-    var start = storeCurrentPos();
-    var expr = parseExprOps(noIn, refShorthandDefaultPos);
+  pp.parseMaybeConditional = function(noIn, refShorthandDefaultPos) {
+    var start = this.currentPos();
+    var expr = this.parseExprOps(noIn, refShorthandDefaultPos);
     if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
-    if (eat(_question)) {
-      var node = startNodeAt(start);
+    if (this.eat(_question)) {
+      var node = this.startNodeAt(start);
       node.test = expr;
-      node.consequent = parseMaybeAssign();
-      expect(_colon);
-      node.alternate = parseMaybeAssign(noIn);
-      return finishNode(node, "ConditionalExpression");
+      node.consequent = this.parseMaybeAssign();
+      this.expect(_colon);
+      node.alternate = this.parseMaybeAssign(noIn);
+      return this.finishNode(node, "ConditionalExpression");
     }
     return expr;
-  }
+  };
 
   // Start the precedence parser.
 
-  function parseExprOps(noIn, refShorthandDefaultPos) {
-    var start = storeCurrentPos();
-    var expr = parseMaybeUnary(refShorthandDefaultPos);
+  pp.parseExprOps = function(noIn, refShorthandDefaultPos) {
+    var start = this.currentPos();
+    var expr = this.parseMaybeUnary(refShorthandDefaultPos);
     if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
-    return parseExprOp(expr, start, -1, noIn);
-  }
+    return this.parseExprOp(expr, start, -1, noIn);
+  };
 
   // Parse binary operators with the operator precedence parsing
   // algorithm. `left` is the left-hand side of the operator.
@@ -2160,465 +2117,465 @@
   // defer further parser to one of its callers when it encounters an
   // operator that has a lower precedence than the set it is parsing.
 
-  function parseExprOp(left, leftStart, minPrec, noIn) {
-    var prec = tokType.binop;
-    if (prec != null && (!noIn || tokType !== _in)) {
+  pp.parseExprOp = function(left, leftStart, minPrec, noIn) {
+    var prec = this.type.binop;
+    if (prec != null && (!noIn || this.type !== _in)) {
       if (prec > minPrec) {
-        var node = startNodeAt(leftStart);
+        var node = this.startNodeAt(leftStart);
         node.left = left;
-        node.operator = tokVal;
-        var op = tokType;
-        next();
-        var start = storeCurrentPos();
-        node.right = parseExprOp(parseMaybeUnary(), start, prec, noIn);
-        finishNode(node, (op === _logicalOR || op === _logicalAND) ? "LogicalExpression" : "BinaryExpression");
-        return parseExprOp(node, leftStart, minPrec, noIn);
+        node.operator = this.value;
+        var op = this.type;
+        this.next();
+        var start = this.currentPos();
+        node.right = this.parseExprOp(this.parseMaybeUnary(), start, prec, noIn);
+        this.finishNode(node, (op === _logicalOR || op === _logicalAND) ? "LogicalExpression" : "BinaryExpression");
+        return this.parseExprOp(node, leftStart, minPrec, noIn);
       }
     }
     return left;
-  }
+  };
 
   // Parse unary operators, both prefix and postfix.
 
-  function parseMaybeUnary(refShorthandDefaultPos) {
-    if (tokType.prefix) {
-      var node = startNode(), update = tokType.isUpdate;
-      node.operator = tokVal;
+  pp.parseMaybeUnary = function(refShorthandDefaultPos) {
+    if (this.type.prefix) {
+      var node = this.startNode(), update = this.type.isUpdate;
+      node.operator = this.value;
       node.prefix = true;
-      next();
-      node.argument = parseMaybeUnary();
-      if (refShorthandDefaultPos && refShorthandDefaultPos.start) unexpected(refShorthandDefaultPos.start);
-      if (update) checkLVal(node.argument);
-      else if (strict && node.operator === "delete" &&
+      this.next();
+      node.argument = this.parseMaybeUnary();
+      if (refShorthandDefaultPos && refShorthandDefaultPos.start) this.unexpected(refShorthandDefaultPos.start);
+      if (update) this.checkLVal(node.argument);
+      else if (this.strict && node.operator === "delete" &&
                node.argument.type === "Identifier")
-        raise(node.start, "Deleting local variable in strict mode");
-      return finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
+        this.raise(node.start, "Deleting local variable in strict mode");
+      return this.finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
     }
-    var start = storeCurrentPos();
-    var expr = parseExprSubscripts(refShorthandDefaultPos);
+    var start = this.currentPos();
+    var expr = this.parseExprSubscripts(refShorthandDefaultPos);
     if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
-    while (tokType.postfix && !canInsertSemicolon()) {
-      var node = startNodeAt(start);
-      node.operator = tokVal;
+    while (this.type.postfix && !this.canInsertSemicolon()) {
+      var node = this.startNodeAt(start);
+      node.operator = this.value;
       node.prefix = false;
       node.argument = expr;
-      checkLVal(expr);
-      next();
-      expr = finishNode(node, "UpdateExpression");
+      this.checkLVal(expr);
+      this.next();
+      expr = this.finishNode(node, "UpdateExpression");
     }
     return expr;
-  }
+  };
 
   // Parse call, dot, and `[]`-subscript expressions.
 
-  function parseExprSubscripts(refShorthandDefaultPos) {
-    var start = storeCurrentPos();
-    var expr = parseExprAtom(refShorthandDefaultPos);
+  pp.parseExprSubscripts = function(refShorthandDefaultPos) {
+    var start = this.currentPos();
+    var expr = this.parseExprAtom(refShorthandDefaultPos);
     if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
-    return parseSubscripts(expr, start);
-  }
+    return this.parseSubscripts(expr, start);
+  };
 
-  function parseSubscripts(base, start, noCalls) {
-    if (eat(_dot)) {
-      var node = startNodeAt(start);
+  pp.parseSubscripts = function(base, start, noCalls) {
+    if (this.eat(_dot)) {
+      var node = this.startNodeAt(start);
       node.object = base;
-      node.property = parseIdent(true);
+      node.property = this.parseIdent(true);
       node.computed = false;
-      return parseSubscripts(finishNode(node, "MemberExpression"), start, noCalls);
-    } else if (eat(_bracketL)) {
-      var node = startNodeAt(start);
+      return this.parseSubscripts(this.finishNode(node, "MemberExpression"), start, noCalls);
+    } else if (this.eat(_bracketL)) {
+      var node = this.startNodeAt(start);
       node.object = base;
-      node.property = parseExpression();
+      node.property = this.parseExpression();
       node.computed = true;
-      expect(_bracketR);
-      return parseSubscripts(finishNode(node, "MemberExpression"), start, noCalls);
-    } else if (!noCalls && eat(_parenL)) {
-      var node = startNodeAt(start);
+      this.expect(_bracketR);
+      return this.parseSubscripts(this.finishNode(node, "MemberExpression"), start, noCalls);
+    } else if (!noCalls && this.eat(_parenL)) {
+      var node = this.startNodeAt(start);
       node.callee = base;
-      node.arguments = parseExprList(_parenR, false);
-      return parseSubscripts(finishNode(node, "CallExpression"), start, noCalls);
-    } else if (tokType === _backQuote) {
-      var node = startNodeAt(start);
+      node.arguments = this.parseExprList(_parenR, false);
+      return this.parseSubscripts(this.finishNode(node, "CallExpression"), start, noCalls);
+    } else if (this.type === _backQuote) {
+      var node = this.startNodeAt(start);
       node.tag = base;
-      node.quasi = parseTemplate();
-      return parseSubscripts(finishNode(node, "TaggedTemplateExpression"), start, noCalls);
+      node.quasi = this.parseTemplate();
+      return this.parseSubscripts(this.finishNode(node, "TaggedTemplateExpression"), start, noCalls);
     } return base;
-  }
+  };
 
   // Parse an atomic expression — either a single token that is an
   // expression, an expression started by a keyword like `function` or
   // `new`, or an expression wrapped in punctuation like `()`, `[]`,
   // or `{}`.
 
-  function parseExprAtom(refShorthandDefaultPos) {
-    switch (tokType) {
+  pp.parseExprAtom = function(refShorthandDefaultPos) {
+    switch (this.type) {
     case _this:
-      var node = startNode();
-      next();
-      return finishNode(node, "ThisExpression");
+      var node = this.startNode();
+      this.next();
+      return this.finishNode(node, "ThisExpression");
 
     case _yield:
-      if (inGenerator) return parseYield();
+      if (this.inGenerator) return this.parseYield();
 
     case _name:
-      var start = storeCurrentPos();
-      var id = parseIdent(tokType !== _name);
-      if (!canInsertSemicolon() && eat(_arrow)) {
-        return parseArrowExpression(startNodeAt(start), [id]);
+      var start = this.currentPos();
+      var id = this.parseIdent(this.type !== _name);
+      if (!this.canInsertSemicolon() && this.eat(_arrow)) {
+        return this.parseArrowExpression(this.startNodeAt(start), [id]);
       }
       return id;
 
     case _regexp:
-      var node = startNode();
-      node.regex = {pattern: tokVal.pattern, flags: tokVal.flags};
-      node.value = tokVal.value;
-      node.raw = input.slice(tokStart, tokEnd);
-      next();
-      return finishNode(node, "Literal");
+      var node = this.startNode();
+      node.regex = {pattern: this.value.pattern, flags: this.value.flags};
+      node.value = this.value.value;
+      node.raw = this.input.slice(this.start, this.end);
+      this.next();
+      return this.finishNode(node, "Literal");
 
     case _num: case _string:
-      var node = startNode();
-      node.value = tokVal;
-      node.raw = input.slice(tokStart, tokEnd);
-      next();
-      return finishNode(node, "Literal");
+      var node = this.startNode();
+      node.value = this.value;
+      node.raw = this.input.slice(this.start, this.end);
+      this.next();
+      return this.finishNode(node, "Literal");
 
     case _null: case _true: case _false:
-      var node = startNode();
-      node.value = tokType.atomValue;
-      node.raw = tokType.keyword;
-      next();
-      return finishNode(node, "Literal");
+      var node = this.startNode();
+      node.value = this.type.atomValue;
+      node.raw = this.type.keyword;
+      this.next();
+      return this.finishNode(node, "Literal");
 
     case _parenL:
-      return parseParenAndDistinguishExpression();
+      return this.parseParenAndDistinguishExpression();
 
     case _bracketL:
-      var node = startNode();
-      next();
+      var node = this.startNode();
+      this.next();
       // check whether this is array comprehension or regular array
-      if (options.ecmaVersion >= 7 && tokType === _for) {
-        return parseComprehension(node, false);
+      if (this.options.ecmaVersion >= 7 && this.type === _for) {
+        return this.parseComprehension(node, false);
       }
-      node.elements = parseExprList(_bracketR, true, true, refShorthandDefaultPos);
-      return finishNode(node, "ArrayExpression");
+      node.elements = this.parseExprList(_bracketR, true, true, refShorthandDefaultPos);
+      return this.finishNode(node, "ArrayExpression");
 
     case _braceL:
-      return parseObj(false, refShorthandDefaultPos);
+      return this.parseObj(false, refShorthandDefaultPos);
 
     case _function:
-      var node = startNode();
-      next();
-      return parseFunction(node, false);
+      var node = this.startNode();
+      this.next();
+      return this.parseFunction(node, false);
 
     case _class:
-      return parseClass(startNode(), false);
+      return this.parseClass(this.startNode(), false);
 
     case _new:
-      return parseNew();
+      return this.parseNew();
 
     case _backQuote:
-      return parseTemplate();
+      return this.parseTemplate();
 
     default:
-      unexpected();
+      this.unexpected();
     }
-  }
+  };
 
-  function parseParenAndDistinguishExpression() {
-    var start = storeCurrentPos(), val;
-    if (options.ecmaVersion >= 6) {
-      next();
+  pp.parseParenAndDistinguishExpression = function() {
+    var start = this.currentPos(), val;
+    if (this.options.ecmaVersion >= 6) {
+      this.next();
 
-      if (options.ecmaVersion >= 7 && tokType === _for) {
-        return parseComprehension(startNodeAt(start), true);
+      if (this.options.ecmaVersion >= 7 && this.type === _for) {
+        return this.parseComprehension(this.startNodeAt(start), true);
       }
 
-      var innerStart = storeCurrentPos(), exprList = [], first = true;
+      var innerStart = this.currentPos(), exprList = [], first = true;
       var refShorthandDefaultPos = {start: 0}, spreadStart, innerParenStart;
-      while (tokType !== _parenR) {
-        first ? first = false : expect(_comma);
-        if (tokType === _ellipsis) {
-          spreadStart = tokStart;
-          exprList.push(parseRest());
+      while (this.type !== _parenR) {
+        first ? first = false : this.expect(_comma);
+        if (this.type === _ellipsis) {
+          spreadStart = this.start;
+          exprList.push(this.parseRest());
           break;
         } else {
-          if (tokType === _parenL && !innerParenStart) {
-            innerParenStart = tokStart;
+          if (this.type === _parenL && !innerParenStart) {
+            innerParenStart = this.start;
           }
-          exprList.push(parseMaybeAssign(false, refShorthandDefaultPos));
+          exprList.push(this.parseMaybeAssign(false, refShorthandDefaultPos));
         }
       }
-      var innerEnd = storeCurrentPos();
-      expect(_parenR);
+      var innerEnd = this.currentPos();
+      this.expect(_parenR);
 
-      if (!canInsertSemicolon() && eat(_arrow)) {
-        if (innerParenStart) unexpected(innerParenStart);
-        return parseArrowExpression(startNodeAt(start), exprList);
+      if (!this.canInsertSemicolon() && this.eat(_arrow)) {
+        if (innerParenStart) this.unexpected(innerParenStart);
+        return this.parseArrowExpression(this.startNodeAt(start), exprList);
       }
 
-      if (!exprList.length) unexpected(lastStart);
-      if (spreadStart) unexpected(spreadStart);
-      if (refShorthandDefaultPos.start) unexpected(refShorthandDefaultPos.start);
+      if (!exprList.length) this.unexpected(this.lastTokStart);
+      if (spreadStart) this.unexpected(spreadStart);
+      if (refShorthandDefaultPos.start) this.unexpected(refShorthandDefaultPos.start);
 
       if (exprList.length > 1) {
-        val = startNodeAt(innerStart);
+        val = this.startNodeAt(innerStart);
         val.expressions = exprList;
-        finishNodeAt(val, "SequenceExpression", innerEnd);
+        this.finishNodeAt(val, "SequenceExpression", innerEnd);
       } else {
         val = exprList[0];
       }
     } else {
-      val = parseParenExpression();
+      val = this.parseParenExpression();
     }
 
-    if (options.preserveParens) {
-      var par = startNodeAt(start);
+    if (this.options.preserveParens) {
+      var par = this.startNodeAt(start);
       par.expression = val;
-      return finishNode(par, "ParenthesizedExpression");
+      return this.finishNode(par, "ParenthesizedExpression");
     } else {
       return val;
     }
-  }
+  };
 
   // New's precedence is slightly tricky. It must allow its argument
   // to be a `[]` or dot subscript expression, but not a call — at
   // least, not without wrapping it in parentheses. Thus, it uses the
 
-  function parseNew() {
-    var node = startNode();
-    next();
-    var start = storeCurrentPos();
-    node.callee = parseSubscripts(parseExprAtom(), start, true);
-    if (eat(_parenL)) node.arguments = parseExprList(_parenR, false);
+  pp.parseNew = function() {
+    var node = this.startNode();
+    this.next();
+    var start = this.currentPos();
+    node.callee = this.parseSubscripts(this.parseExprAtom(), start, true);
+    if (this.eat(_parenL)) node.arguments = this.parseExprList(_parenR, false);
     else node.arguments = empty;
-    return finishNode(node, "NewExpression");
-  }
+    return this.finishNode(node, "NewExpression");
+  };
 
   // Parse template expression.
 
-  function parseTemplateElement() {
-    var elem = startNode();
+  pp.parseTemplateElement = function() {
+    var elem = this.startNode();
     elem.value = {
-      raw: input.slice(tokStart, tokEnd),
-      cooked: tokVal
+      raw: this.input.slice(this.start, this.end),
+      cooked: this.value
     };
-    next();
-    elem.tail = tokType === _backQuote;
-    return finishNode(elem, "TemplateElement");
-  }
+    this.next();
+    elem.tail = this.type === _backQuote;
+    return this.finishNode(elem, "TemplateElement");
+  };
 
-  function parseTemplate() {
-    var node = startNode();
-    next();
+  pp.parseTemplate = function() {
+    var node = this.startNode();
+    this.next();
     node.expressions = [];
-    var curElt = parseTemplateElement();
+    var curElt = this.parseTemplateElement();
     node.quasis = [curElt];
     while (!curElt.tail) {
-      expect(_dollarBraceL);
-      node.expressions.push(parseExpression());
-      expect(_braceR);
-      node.quasis.push(curElt = parseTemplateElement());
+      this.expect(_dollarBraceL);
+      node.expressions.push(this.parseExpression());
+      this.expect(_braceR);
+      node.quasis.push(curElt = this.parseTemplateElement());
     }
-    next();
-    return finishNode(node, "TemplateLiteral");
-  }
+    this.next();
+    return this.finishNode(node, "TemplateLiteral");
+  };
 
   // Parse an object literal or binding pattern.
 
-  function parseObj(isPattern, refShorthandDefaultPos) {
-    var node = startNode(), first = true, propHash = {};
+  pp.parseObj = function(isPattern, refShorthandDefaultPos) {
+    var node = this.startNode(), first = true, propHash = {};
     node.properties = [];
-    next();
-    while (!eat(_braceR)) {
+    this.next();
+    while (!this.eat(_braceR)) {
       if (!first) {
-        expect(_comma);
-        if (options.allowTrailingCommas && eat(_braceR)) break;
+        this.expect(_comma);
+        if (this.options.allowTrailingCommas && this.eat(_braceR)) break;
       } else first = false;
 
-      var prop = startNode(), isGenerator, start;
-      if (options.ecmaVersion >= 6) {
+      var prop = this.startNode(), isGenerator, start;
+      if (this.options.ecmaVersion >= 6) {
         prop.method = false;
         prop.shorthand = false;
         if (isPattern || refShorthandDefaultPos) {
-          start = storeCurrentPos();
+          start = this.currentPos();
         }
         if (!isPattern) {
-          isGenerator = eat(_star);
+          isGenerator = this.eat(_star);
         }
       }
-      parsePropertyName(prop);
-      if (eat(_colon)) {
-        prop.value = isPattern ? parseMaybeDefault() : parseMaybeAssign(false, refShorthandDefaultPos);
+      this.parsePropertyName(prop);
+      if (this.eat(_colon)) {
+        prop.value = isPattern ? this.parseMaybeDefault() : this.parseMaybeAssign(false, refShorthandDefaultPos);
         prop.kind = "init";
-      } else if (options.ecmaVersion >= 6 && tokType === _parenL) {
-        if (isPattern) unexpected();
+      } else if (this.options.ecmaVersion >= 6 && this.type === _parenL) {
+        if (isPattern) this.unexpected();
         prop.kind = "init";
         prop.method = true;
-        prop.value = parseMethod(isGenerator);
-      } else if (options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" &&
+        prop.value = this.parseMethod(isGenerator);
+      } else if (this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" &&
                  (prop.key.name === "get" || prop.key.name === "set") &&
-                 (tokType != _comma && tokType != _braceR)) {
-        if (isGenerator || isPattern) unexpected();
+                 (this.type != _comma && this.type != _braceR)) {
+        if (isGenerator || isPattern) this.unexpected();
         prop.kind = prop.key.name;
-        parsePropertyName(prop);
-        prop.value = parseMethod(false);
-      } else if (options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+        this.parsePropertyName(prop);
+        prop.value = this.parseMethod(false);
+      } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
         prop.kind = "init";
         if (isPattern) {
-          prop.value = parseMaybeDefault(start, prop.key);
-        } else if (tokType === _eq && refShorthandDefaultPos) {
+          prop.value = this.parseMaybeDefault(start, prop.key);
+        } else if (this.type === _eq && refShorthandDefaultPos) {
           if (!refShorthandDefaultPos.start)
-            refShorthandDefaultPos.start = tokStart;
-          prop.value = parseMaybeDefault(start, prop.key);
+            refShorthandDefaultPos.start = this.start;
+          prop.value = this.parseMaybeDefault(start, prop.key);
         } else {
           prop.value = prop.key;
         }
         prop.shorthand = true;
-      } else unexpected();
+      } else this.unexpected();
 
-      checkPropClash(prop, propHash);
-      node.properties.push(finishNode(prop, "Property"));
+      this.checkPropClash(prop, propHash);
+      node.properties.push(this.finishNode(prop, "Property"));
     }
-    return finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
-  }
+    return this.finishNode(node, isPattern ? "ObjectPattern" : "ObjectExpression");
+  };
 
-  function parsePropertyName(prop) {
-    if (options.ecmaVersion >= 6) {
-      if (eat(_bracketL)) {
+  pp.parsePropertyName = function(prop) {
+    if (this.options.ecmaVersion >= 6) {
+      if (this.eat(_bracketL)) {
         prop.computed = true;
-        prop.key = parseExpression();
-        expect(_bracketR);
+        prop.key = this.parseExpression();
+        this.expect(_bracketR);
         return;
       } else {
         prop.computed = false;
       }
     }
-    prop.key = (tokType === _num || tokType === _string) ? parseExprAtom() : parseIdent(true);
-  }
+    prop.key = (this.type === _num || this.type === _string) ? this.parseExprAtom() : this.parseIdent(true);
+  };
 
   // Initialize empty function node.
 
-  function initFunction(node) {
+  pp.initFunction = function(node) {
     node.id = null;
-    if (options.ecmaVersion >= 6) {
+    if (this.options.ecmaVersion >= 6) {
       node.generator = false;
       node.expression = false;
     }
-  }
+  };
 
   // Parse a function declaration or literal (depending on the
   // `isStatement` parameter).
 
-  function parseFunction(node, isStatement, allowExpressionBody) {
-    initFunction(node);
-    if (options.ecmaVersion >= 6) {
-      node.generator = eat(_star);
+  pp.parseFunction = function(node, isStatement, allowExpressionBody) {
+    this.initFunction(node);
+    if (this.options.ecmaVersion >= 6) {
+      node.generator = this.eat(_star);
     }
-    if (isStatement || tokType === _name) {
-      node.id = parseIdent();
+    if (isStatement || this.type === _name) {
+      node.id = this.parseIdent();
     }
-    expect(_parenL);
-    node.params = parseBindingList(_parenR, false);
-    parseFunctionBody(node, allowExpressionBody);
-    return finishNode(node, isStatement ? "FunctionDeclaration" : "FunctionExpression");
-  }
+    this.expect(_parenL);
+    node.params = this.parseBindingList(_parenR, false);
+    this.parseFunctionBody(node, allowExpressionBody);
+    return this.finishNode(node, isStatement ? "FunctionDeclaration" : "FunctionExpression");
+  };
 
   // Parse object or class method.
 
-  function parseMethod(isGenerator) {
-    var node = startNode();
-    initFunction(node);
-    expect(_parenL);
-    node.params = parseBindingList(_parenR, false);
+  pp.parseMethod = function(isGenerator) {
+    var node = this.startNode();
+    this.initFunction(node);
+    this.expect(_parenL);
+    node.params = this.parseBindingList(_parenR, false);
     var allowExpressionBody;
-    if (options.ecmaVersion >= 6) {
+    if (this.options.ecmaVersion >= 6) {
       node.generator = isGenerator;
       allowExpressionBody = true;
     } else {
       allowExpressionBody = false;
     }
-    parseFunctionBody(node, allowExpressionBody);
-    return finishNode(node, "FunctionExpression");
-  }
+    this.parseFunctionBody(node, allowExpressionBody);
+    return this.finishNode(node, "FunctionExpression");
+  };
 
   // Parse arrow function expression with given parameters.
 
-  function parseArrowExpression(node, params) {
-    initFunction(node);
-    node.params = toAssignableList(params, true);
-    parseFunctionBody(node, true);
-    return finishNode(node, "ArrowFunctionExpression");
-  }
+  pp.parseArrowExpression = function(node, params) {
+    this.initFunction(node);
+    node.params = this.toAssignableList(params, true);
+    this.parseFunctionBody(node, true);
+    return this.finishNode(node, "ArrowFunctionExpression");
+  };
 
   // Parse function body and check parameters.
 
-  function parseFunctionBody(node, allowExpression) {
-    var isExpression = allowExpression && tokType !== _braceL;
+  pp.parseFunctionBody = function(node, allowExpression) {
+    var isExpression = allowExpression && this.type !== _braceL;
 
     if (isExpression) {
-      node.body = parseMaybeAssign();
+      node.body = this.parseMaybeAssign();
       node.expression = true;
     } else {
       // Start a new scope with regard to labels and the `inFunction`
       // flag (restore them to their old value afterwards).
-      var oldInFunc = inFunction, oldInGen = inGenerator, oldLabels = labels;
-      inFunction = true; inGenerator = node.generator; labels = [];
-      node.body = parseBlock(true);
+      var oldInFunc = this.inFunction, oldInGen = this.inGenerator, oldLabels = this.labels;
+      this.inFunction = true; this.inGenerator = node.generator; this.labels = [];
+      node.body = this.parseBlock(true);
       node.expression = false;
-      inFunction = oldInFunc; inGenerator = oldInGen; labels = oldLabels;
+      this.inFunction = oldInFunc; this.inGenerator = oldInGen; this.labels = oldLabels;
     }
 
     // If this is a strict mode function, verify that argument names
     // are not repeated, and it does not try to bind the words `eval`
     // or `arguments`.
-    if (strict || !isExpression && node.body.body.length && isUseStrict(node.body.body[0])) {
+    if (this.strict || !isExpression && node.body.body.length && this.isUseStrict(node.body.body[0])) {
       var nameHash = {};
       if (node.id)
-        checkFunctionParam(node.id, {});
+        this.checkFunctionParam(node.id, {});
       for (var i = 0; i < node.params.length; i++)
-        checkFunctionParam(node.params[i], nameHash);
+        this.checkFunctionParam(node.params[i], nameHash);
     }
-  }
+  };
 
   // Parse a class declaration or literal (depending on the
   // `isStatement` parameter).
 
-  function parseClass(node, isStatement) {
-    next();
-    node.id = tokType === _name ? parseIdent() : isStatement ? unexpected() : null;
-    node.superClass = eat(_extends) ? parseExprSubscripts() : null;
-    var classBody = startNode();
+  pp.parseClass = function(node, isStatement) {
+    this.next();
+    node.id = this.type === _name ? this.parseIdent() : isStatement ? this.unexpected() : null;
+    node.superClass = this.eat(_extends) ? this.parseExprSubscripts() : null;
+    var classBody = this.startNode();
     classBody.body = [];
-    expect(_braceL);
-    while (!eat(_braceR)) {
-      if (eat(_semi)) continue;
-      var method = startNode();
-      var isGenerator = eat(_star);
-      parsePropertyName(method);
-      if (tokType !== _parenL && !method.computed && method.key.type === "Identifier" &&
+    this.expect(_braceL);
+    while (!this.eat(_braceR)) {
+      if (this.eat(_semi)) continue;
+      var method = this.startNode();
+      var isGenerator = this.eat(_star);
+      this.parsePropertyName(method);
+      if (this.type !== _parenL && !method.computed && method.key.type === "Identifier" &&
           method.key.name === "static") {
-        if (isGenerator) unexpected();
+        if (isGenerator) this.unexpected();
         method['static'] = true;
-        isGenerator = eat(_star);
-        parsePropertyName(method);
+        isGenerator = this.eat(_star);
+        this.parsePropertyName(method);
       } else {
         method['static'] = false;
       }
-      if (tokType !== _parenL && !method.computed && method.key.type === "Identifier" &&
+      if (this.type !== _parenL && !method.computed && method.key.type === "Identifier" &&
           (method.key.name === "get" || method.key.name === "set")) {
-        if (isGenerator) unexpected();
+        if (isGenerator) this.unexpected();
         method.kind = method.key.name;
-        parsePropertyName(method);
+        this.parsePropertyName(method);
       } else {
         method.kind = "";
       }
-      method.value = parseMethod(isGenerator);
-      classBody.body.push(finishNode(method, "MethodDefinition"));
+      method.value = this.parseMethod(isGenerator);
+      classBody.body.push(this.finishNode(method, "MethodDefinition"));
     }
-    node.body = finishNode(classBody, "ClassBody");
-    return finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
-  }
+    node.body = this.finishNode(classBody, "ClassBody");
+    return this.finishNode(node, isStatement ? "ClassDeclaration" : "ClassExpression");
+  };
 
   // Parses a comma-separated list of expressions, and returns them as
   // an array. `close` is the token type that ends the list, and
@@ -2626,64 +2583,64 @@
   // nothing in between them to be parsed as `null` (which is needed
   // for array literals).
 
-  function parseExprList(close, allowTrailingComma, allowEmpty, refShorthandDefaultPos) {
+  pp.parseExprList = function(close, allowTrailingComma, allowEmpty, refShorthandDefaultPos) {
     var elts = [], first = true;
-    while (!eat(close)) {
+    while (!this.eat(close)) {
       if (!first) {
-        expect(_comma);
-        if (allowTrailingComma && options.allowTrailingCommas && eat(close)) break;
+        this.expect(_comma);
+        if (allowTrailingComma && this.options.allowTrailingCommas && this.eat(close)) break;
       } else first = false;
 
-      if (allowEmpty && tokType === _comma) {
+      if (allowEmpty && this.type === _comma) {
         elts.push(null);
       } else {
-        if (tokType === _ellipsis)
-          elts.push(parseSpread(refShorthandDefaultPos));
+        if (this.type === _ellipsis)
+          elts.push(this.parseSpread(refShorthandDefaultPos));
         else
-          elts.push(parseMaybeAssign(false, refShorthandDefaultPos));
+          elts.push(this.parseMaybeAssign(false, refShorthandDefaultPos));
       }
     }
     return elts;
-  }
+  };
 
   // Parse the next token as an identifier. If `liberal` is true (used
   // when parsing properties), it will also convert keywords into
   // identifiers.
 
-  function parseIdent(liberal) {
-    var node = startNode();
-    if (liberal && options.forbidReserved == "everywhere") liberal = false;
-    if (tokType === _name) {
+  pp.parseIdent = function(liberal) {
+    var node = this.startNode();
+    if (liberal && this.options.forbidReserved == "everywhere") liberal = false;
+    if (this.type === _name) {
       if (!liberal &&
-          (options.forbidReserved &&
-           (options.ecmaVersion === 3 ? isReservedWord3 : isReservedWord5)(tokVal) ||
-           strict && isStrictReservedWord(tokVal)) &&
-          input.slice(tokStart, tokEnd).indexOf("\\") == -1)
-        raise(tokStart, "The keyword '" + tokVal + "' is reserved");
-      node.name = tokVal;
-    } else if (liberal && tokType.keyword) {
-      node.name = tokType.keyword;
+          (this.options.forbidReserved &&
+           (this.options.ecmaVersion === 3 ? isReservedWord3 : isReservedWord5)(this.value) ||
+           this.strict && isStrictReservedWord(this.value)) &&
+          this.input.slice(this.start, this.end).indexOf("\\") == -1)
+        this.raise(this.start, "The keyword '" + this.value + "' is reserved");
+      node.name = this.value;
+    } else if (liberal && this.type.keyword) {
+      node.name = this.type.keyword;
     } else {
-      unexpected();
+      this.unexpected();
     }
-    next();
-    return finishNode(node, "Identifier");
-  }
+    this.next();
+    return this.finishNode(node, "Identifier");
+  };
 
   // Parses module export declaration.
 
-  function parseExport(node) {
-    next();
+  pp.parseExport = function(node) {
+    this.next();
     // export var|const|let|function|class ...;
-    if (tokType === _var || tokType === _const || tokType === _let || tokType === _function || tokType === _class) {
-      node.declaration = parseStatement(true);
+    if (this.type === _var || this.type === _const || this.type === _let || this.type === _function || this.type === _class) {
+      node.declaration = this.parseStatement(true);
       node['default'] = false;
       node.specifiers = null;
       node.source = null;
     } else
     // export default ...;
-    if (eat(_default)) {
-      var expr = parseMaybeAssign();
+    if (this.eat(_default)) {
+      var expr = this.parseMaybeAssign();
       if (expr.id) {
         switch (expr.type) {
           case "FunctionExpression": expr.type = "FunctionDeclaration"; break;
@@ -2694,144 +2651,144 @@
       node['default'] = true;
       node.specifiers = null;
       node.source = null;
-      semicolon();
+      this.semicolon();
     } else {
       // export * from '...';
       // export { x, y as z } [from '...'];
-      var isBatch = tokType === _star;
+      var isBatch = this.type === _star;
       node.declaration = null;
       node['default'] = false;
-      node.specifiers = parseExportSpecifiers();
-      if (eatContextual("from")) {
-        node.source = tokType === _string ? parseExprAtom() : unexpected();
+      node.specifiers = this.parseExportSpecifiers();
+      if (this.eatContextual("from")) {
+        node.source = this.type === _string ? this.parseExprAtom() : this.unexpected();
       } else {
-        if (isBatch) unexpected();
+        if (isBatch) this.unexpected();
         node.source = null;
       }
-      semicolon();
+      this.semicolon();
     }
-    return finishNode(node, "ExportDeclaration");
-  }
+    return this.finishNode(node, "ExportDeclaration");
+  };
 
   // Parses a comma-separated list of module exports.
 
-  function parseExportSpecifiers() {
+  pp.parseExportSpecifiers = function() {
     var nodes = [], first = true;
-    if (tokType === _star) {
+    if (this.type === _star) {
       // export * from '...'
-      var node = startNode();
-      next();
-      nodes.push(finishNode(node, "ExportBatchSpecifier"));
+      var node = this.startNode();
+      this.next();
+      nodes.push(this.finishNode(node, "ExportBatchSpecifier"));
     } else {
       // export { x, y as z } [from '...']
-      expect(_braceL);
-      while (!eat(_braceR)) {
+      this.expect(_braceL);
+      while (!this.eat(_braceR)) {
         if (!first) {
-          expect(_comma);
-          if (options.allowTrailingCommas && eat(_braceR)) break;
+          this.expect(_comma);
+          if (this.options.allowTrailingCommas && this.eat(_braceR)) break;
         } else first = false;
 
-        var node = startNode();
-        node.id = parseIdent(tokType === _default);
-        node.name = eatContextual("as") ? parseIdent(true) : null;
-        nodes.push(finishNode(node, "ExportSpecifier"));
+        var node = this.startNode();
+        node.id = this.parseIdent(this.type === _default);
+        node.name = this.eatContextual("as") ? this.parseIdent(true) : null;
+        nodes.push(this.finishNode(node, "ExportSpecifier"));
       }
     }
     return nodes;
-  }
+  };
 
   // Parses import declaration.
 
-  function parseImport(node) {
-    next();
+  pp.parseImport = function(node) {
+    this.next();
     // import '...';
-    if (tokType === _string) {
+    if (this.type === _string) {
       node.specifiers = [];
-      node.source = parseExprAtom();
+      node.source = this.parseExprAtom();
       node.kind = "";
     } else {
-      node.specifiers = parseImportSpecifiers();
-      expectContextual("from");
-      node.source = tokType === _string ? parseExprAtom() : unexpected();
+      node.specifiers = this.parseImportSpecifiers();
+      this.expectContextual("from");
+      node.source = this.type === _string ? this.parseExprAtom() : this.unexpected();
     }
-    semicolon();
-    return finishNode(node, "ImportDeclaration");
-  }
+    this.semicolon();
+    return this.finishNode(node, "ImportDeclaration");
+  };
 
   // Parses a comma-separated list of module imports.
 
-  function parseImportSpecifiers() {
+  pp.parseImportSpecifiers = function() {
     var nodes = [], first = true;
-    if (tokType === _name) {
+    if (this.type === _name) {
       // import defaultObj, { x, y as z } from '...'
-      var node = startNode();
-      node.id = parseIdent();
-      checkLVal(node.id, true);
+      var node = this.startNode();
+      node.id = this.parseIdent();
+      this.checkLVal(node.id, true);
       node.name = null;
       node['default'] = true;
-      nodes.push(finishNode(node, "ImportSpecifier"));
-      if (!eat(_comma)) return nodes;
+      nodes.push(this.finishNode(node, "ImportSpecifier"));
+      if (!this.eat(_comma)) return nodes;
     }
-    if (tokType === _star) {
-      var node = startNode();
-      next();
-      expectContextual("as");
-      node.name = parseIdent();
-      checkLVal(node.name, true);
-      nodes.push(finishNode(node, "ImportBatchSpecifier"));
+    if (this.type === _star) {
+      var node = this.startNode();
+      this.next();
+      this.expectContextual("as");
+      node.name = this.parseIdent();
+      this.checkLVal(node.name, true);
+      nodes.push(this.finishNode(node, "ImportBatchSpecifier"));
       return nodes;
     }
-    expect(_braceL);
-    while (!eat(_braceR)) {
+    this.expect(_braceL);
+    while (!this.eat(_braceR)) {
       if (!first) {
-        expect(_comma);
-        if (options.allowTrailingCommas && eat(_braceR)) break;
+        this.expect(_comma);
+        if (this.options.allowTrailingCommas && this.eat(_braceR)) break;
       } else first = false;
 
-      var node = startNode();
-      node.id = parseIdent(true);
-      node.name = eatContextual("as") ? parseIdent() : null;
-      checkLVal(node.name || node.id, true);
+      var node = this.startNode();
+      node.id = this.parseIdent(true);
+      node.name = this.eatContextual("as") ? this.parseIdent() : null;
+      this.checkLVal(node.name || node.id, true);
       node['default'] = false;
-      nodes.push(finishNode(node, "ImportSpecifier"));
+      nodes.push(this.finishNode(node, "ImportSpecifier"));
     }
     return nodes;
-  }
+  };
 
   // Parses yield expression inside generator.
 
-  function parseYield() {
-    var node = startNode();
-    next();
-    if (eat(_semi) || canInsertSemicolon()) {
+  pp.parseYield = function() {
+    var node = this.startNode();
+    this.next();
+    if (this.eat(_semi) || this.canInsertSemicolon()) {
       node.delegate = false;
       node.argument = null;
     } else {
-      node.delegate = eat(_star);
-      node.argument = parseMaybeAssign();
+      node.delegate = this.eat(_star);
+      node.argument = this.parseMaybeAssign();
     }
-    return finishNode(node, "YieldExpression");
-  }
+    return this.finishNode(node, "YieldExpression");
+  };
 
   // Parses array and generator comprehensions.
 
-  function parseComprehension(node, isGenerator) {
+  pp.parseComprehension = function(node, isGenerator) {
     node.blocks = [];
-    while (tokType === _for) {
-      var block = startNode();
-      next();
-      expect(_parenL);
-      block.left = parseBindingAtom();
-      checkLVal(block.left, true);
-      expectContextual("of");
-      block.right = parseExpression();
-      expect(_parenR);
-      node.blocks.push(finishNode(block, "ComprehensionBlock"));
+    while (this.type === _for) {
+      var block = this.startNode();
+      this.next();
+      this.expect(_parenL);
+      block.left = this.parseBindingAtom();
+      this.checkLVal(block.left, true);
+      this.expectContextual("of");
+      block.right = this.parseExpression();
+      this.expect(_parenR);
+      node.blocks.push(this.finishNode(block, "ComprehensionBlock"));
     }
-    node.filter = eat(_if) ? parseParenExpression() : null;
-    node.body = parseExpression();
-    expect(isGenerator ? _parenR : _bracketR);
+    node.filter = this.eat(_if) ? this.parseParenExpression() : null;
+    node.body = this.parseExpression();
+    this.expect(isGenerator ? _parenR : _bracketR);
     node.generator = isGenerator;
-    return finishNode(node, "ComprehensionExpression");
-  }
+    return this.finishNode(node, "ComprehensionExpression");
+  };
 });

--- a/acorn.js
+++ b/acorn.js
@@ -38,7 +38,6 @@
   exports.parse = function(input, options) {
     var p = new Parser(options, input);
     var startPos = p.options.locations ? [p.pos, p.curPosition()] : p.pos;
-    p.skipSpace();
     p.readToken();
     return p.parseTopLevel(p.options.program || p.startNodeAt(startPos));
   };
@@ -126,7 +125,6 @@
 
   exports.parseExpressionAt = function(input, pos, options) {
     var p = new Parser(options, input, pos);
-    p.skipSpace();
     p.readToken();
     return p.parseExpression();
   };
@@ -174,7 +172,6 @@
 
   exports.tokenize = function(input, options) {
     var p = new Parser(options, input);
-    p.skipSpace();
 
     function getToken() {
       p.lastTokEnd = p.end;
@@ -196,7 +193,6 @@
         }
       }
       p.exprAllowed = !!exprAllowed;
-      p.skipSpace();
     };
 
     // If we're in an ES6 environment, make this an iterator.
@@ -614,7 +610,6 @@
         --this.curLine;
       }
     }
-    this.skipSpace();
     this.readToken();
   };
 
@@ -626,12 +621,14 @@
   // properties.
 
   pp.readToken = function() {
+    var inTemplate = this.curTokContext() === q_tmpl;
+    if (!inTemplate) this.skipSpace();
+
     this.start = this.pos;
     if (this.options.locations) this.startLoc = this.curPosition();
     if (this.pos >= this.input.length) return this.finishToken(_eof);
 
-    if (this.curTokContext() === q_tmpl)
-      return this.readTmplToken();
+    if (inTemplate) return this.readTmplToken();
 
     var code = this.input.charCodeAt(this.pos);
 
@@ -755,19 +752,17 @@
   pp.finishToken = function(type, val) {
     this.end = this.pos;
     if (this.options.locations) this.endLoc = this.curPosition();
-    var prevType = this.type, preserveSpace = false;
+    var prevType = this.type;
     this.type = type;
     this.value = val;
 
     // Update context info
     if (type === _parenR || type === _braceR) {
       var out = this.context.pop();
-      if (out === b_tmpl) {
-        preserveSpace = true;
-      } else if (out === b_stat && this.curTokContext() === f_expr) {
+      if (out === b_stat && this.curTokContext() === f_expr) {
         this.context.pop();
         this.exprAllowed = false;
-      } else {
+      } else if (out !== b_tmpl) {
         this.exprAllowed = !(out && out.isExpr);
       }
     } else if (type === _braceL) {
@@ -790,18 +785,14 @@
       }
       this.exprAllowed = false;
     } else if (type === _backQuote) {
-      if (this.curTokContext() === q_tmpl) {
+      if (this.curTokContext() === q_tmpl)
         this.context.pop();
-      } else {
+      else
         this.context.push(q_tmpl);
-        preserveSpace = true;
-      }
       this.exprAllowed = false;
     } else {
       this.exprAllowed = type.beforeExpr;
     }
-
-    if (!preserveSpace) this.skipSpace();
   };
 
   // ### Token reading

--- a/acorn.js
+++ b/acorn.js
@@ -281,6 +281,7 @@
     this.prefix = kind && kind.indexOf("prefix") > -1;
     this.postfix = kind && kind.indexOf("postfix") > -1;
     this.binop = binop || null;
+    this.updateContext = null;
   }
 
 
@@ -391,6 +392,52 @@
   kw("typeof", true, "prefix");
   kw("void", true, "prefix");
   kw("delete", true, "prefix");
+
+  // Update tokenizer context for a given token type
+
+  tt.parenR.updateContext = tt.braceR.updateContext = function() {
+    var out = this.context.pop();
+    if (out === b_stat && this.curTokContext() === f_expr) {
+      this.context.pop();
+      this.exprAllowed = false;
+    } else if (out !== b_tmpl) {
+      this.exprAllowed = !(out && out.isExpr);
+    }
+  };
+
+  tt.braceL.updateContext = function(prevType) {
+    this.context.push(this.braceIsBlock(prevType) ? b_stat : b_expr);
+    this.exprAllowed = true;
+  };
+
+  tt.dollarBraceL.updateContext = function() {
+    this.context.push(b_tmpl);
+    this.exprAllowed = true;
+  };
+
+  tt.parenL.updateContext = function(prevType) {
+    var statementParens = prevType === tt._if || prevType === tt._for || prevType === tt._with || prevType === tt._while;
+    this.context.push(statementParens ? p_stat : p_expr);
+    this.exprAllowed = true;
+  };
+
+  tt.incDec.updateContext = function() {
+    // tokExprAllowed stays unchanged
+  };
+
+  tt._function.updateContext = function() {
+    if (this.curTokContext() !== b_stat)
+      this.context.push(f_expr);
+    this.exprAllowed = false;
+  };
+
+  tt.backQuote.updateContext = function() {
+    if (this.curTokContext() === q_tmpl)
+      this.context.pop();
+    else
+      this.context.push(q_tmpl);
+    this.exprAllowed = false;
+  };
 
   // This is a trick taken from Esprima. It turns out that, on
   // non-Chrome browsers, to check whether a string is in a set, a
@@ -772,43 +819,13 @@
     this.type = type;
     this.value = val;
 
-    // Update context info
-    if (type === tt.parenR || type === tt.braceR) {
-      var out = this.context.pop();
-      if (out === b_stat && this.curTokContext() === f_expr) {
-        this.context.pop();
-        this.exprAllowed = false;
-      } else if (out !== b_tmpl) {
-        this.exprAllowed = !(out && out.isExpr);
-      }
-    } else if (type === tt.braceL) {
-      this.context.push(this.braceIsBlock(prevType) ? b_stat : b_expr);
-      this.exprAllowed = true;
-    } else if (type === tt.dollarBraceL) {
-      this.context.push(b_tmpl);
-      this.exprAllowed = true;
-    } else if (type == tt.parenL) {
-      var statementParens = prevType === tt._if || prevType === tt._for || prevType === tt._with || prevType === tt._while;
-      this.context.push(statementParens ? p_stat : p_expr);
-      this.exprAllowed = true;
-    } else if (type == tt.incDec) {
-      // tokExprAllowed stays unchanged
-    } else if (type.keyword && prevType == tt.dot) {
+    var update;
+    if (type.keyword && prevType == tt.dot)
       this.exprAllowed = false;
-    } else if (type == tt._function) {
-      if (this.curTokContext() !== b_stat) {
-        this.context.push(f_expr);
-      }
-      this.exprAllowed = false;
-    } else if (type === tt.backQuote) {
-      if (this.curTokContext() === q_tmpl)
-        this.context.pop();
-      else
-        this.context.push(q_tmpl);
-      this.exprAllowed = false;
-    } else {
+    else if (update = type.updateContext)
+      update.call(this, prevType);
+    else
       this.exprAllowed = type.beforeExpr;
-    }
   };
 
   // ### Token reading

--- a/acorn.js
+++ b/acorn.js
@@ -202,7 +202,7 @@
           next: function () {
             var token = getToken();
             return {
-              done: token.type === _eof,
+              done: token.type === tt.eof,
               value: token
             };
           }
@@ -263,16 +263,6 @@
   // All token type variables start with an underscore, to make them
   // easy to recognize.
 
-  // These are the general types. The `type` property is only used to
-  // make them recognizeable when debugging.
-
-  var _num = {type: "num"}, _regexp = {type: "regexp"}, _string = {type: "string"};
-  var _name = {type: "name"}, _eof = {type: "eof"};
-
-  // Keyword tokens. The `keyword` property (also used in keyword-like
-  // operators) indicates that the token originated from an
-  // identifier-like word, which is used when parsing property names.
-  //
   // The `beforeExpr` property is used to disambiguate between regular
   // expressions and divisions. It is set on all token types that can
   // be followed by an expression (thus, a slash after them would be a
@@ -282,99 +272,125 @@
   // to know when parsing a label, in order to allow or disallow
   // continue jumps to that label.
 
-  var _break = {keyword: "break"}, _case = {keyword: "case", beforeExpr: true}, _catch = {keyword: "catch"};
-  var _continue = {keyword: "continue"}, _debugger = {keyword: "debugger"}, _default = {keyword: "default"};
-  var _do = {keyword: "do", isLoop: true}, _else = {keyword: "else", beforeExpr: true};
-  var _finally = {keyword: "finally"}, _for = {keyword: "for", isLoop: true}, _function = {keyword: "function"};
-  var _if = {keyword: "if"}, _return = {keyword: "return", beforeExpr: true}, _switch = {keyword: "switch"};
-  var _throw = {keyword: "throw", beforeExpr: true}, _try = {keyword: "try"}, _var = {keyword: "var"};
-  var _let = {keyword: "let"}, _const = {keyword: "const"};
-  var _while = {keyword: "while", isLoop: true}, _with = {keyword: "with"}, _new = {keyword: "new", beforeExpr: true};
-  var _this = {keyword: "this"};
-  var _class = {keyword: "class"}, _extends = {keyword: "extends", beforeExpr: true};
-  var _export = {keyword: "export"}, _import = {keyword: "import"};
-  var _yield = {keyword: "yield", beforeExpr: true};
+  function TokenType(label, beforeExpr, binop, kind, keyword) {
+    this.label = label;
+    this.keyword = keyword;
+    this.beforeExpr = !!beforeExpr;
+    this.isLoop = kind === "loop";
+    this.isAssign = kind === "assign";
+    this.prefix = kind && kind.indexOf("prefix") > -1;
+    this.postfix = kind && kind.indexOf("postfix") > -1;
+    this.binop = binop || null;
+  }
 
-  // The keywords that denote values.
 
-  var _null = {keyword: "null", atomValue: null}, _true = {keyword: "true", atomValue: true};
-  var _false = {keyword: "false", atomValue: false};
+  function binop(name, prec) {
+    return new TokenType(name, true, prec);
+  }
 
-  // Some keywords are treated as regular operators. `in` sometimes
-  // (when parsing `for`) needs to be tested against specifically, so
-  // we assign a variable name to it for quick comparing.
+  var tt = exports.tokTypes = {
+    num: new TokenType("num"),
+    regexp: new TokenType("regexp"),
+    string: new TokenType("string"),
+    name: new TokenType("name"),
+    eof: new TokenType("eof"),
 
-  var _in = {keyword: "in", binop: 7, beforeExpr: true};
+    // Punctuation token types.
+    bracketL: new TokenType("[", true),
+    bracketR: new TokenType("]"),
+    braceL: new TokenType("{", true),
+    braceR: new TokenType("}"),
+    parenL: new TokenType("(", true),
+    parenR: new TokenType(")"),
+    comma: new TokenType(",", true),
+    semi: new TokenType(";", true),
+    colon: new TokenType(":", true),
+    dot: new TokenType("."),
+    question: new TokenType("?", true),
+    arrow: new TokenType("=>", true),
+    template: new TokenType("template"),
+    ellipsis: new TokenType("...", true),
+    backQuote: new TokenType("`"),
+    dollarBraceL: new TokenType("${", true),
+
+    // Operators. These carry several kinds of properties to help the
+    // parser use them properly (the presence of these properties is
+    // what categorizes them as operators).
+    //
+    // `binop`, when present, specifies that this operator is a binary
+    // operator, and will refer to its precedence.
+    //
+    // `prefix` and `postfix` mark the operator as a prefix or postfix
+    // unary operator.
+    //
+    // `isAssign` marks all of `=`, `+=`, `-=` etcetera, which act as
+    // binary operators with a very low precedence, that should result
+    // in AssignmentExpression nodes.
+
+    eq: new TokenType("=", true, null, "assign"),
+    assign: new TokenType("_=", true, null, "assign"),
+    incDec: new TokenType("++/--", false, null, "prefix postfix"),
+    prefix: new TokenType("prefix", true, null, "prefix"),
+    logicalOR: binop("||", 1),
+    logicalAND: binop("&&", 2),
+    bitwiseOR: binop("|", 3),
+    bitwiseXOR: binop("^", 4),
+    bitwiseAND: binop("&", 5),
+    equality: binop("==/!=", 6),
+    relational: binop("</>", 7),
+    bitShift: binop("<</>>", 8),
+    plusMin: new TokenType("+/-", true, 9, "prefix"),
+    modulo: binop("%", 10),
+    star: binop("*", 10),
+    slash: binop("/", 10)
+  };
 
   // Map keyword names to token types.
 
-  var keywordTypes = {"break": _break, "case": _case, "catch": _catch,
-                      "continue": _continue, "debugger": _debugger, "default": _default,
-                      "do": _do, "else": _else, "finally": _finally, "for": _for,
-                      "function": _function, "if": _if, "return": _return, "switch": _switch,
-                      "throw": _throw, "try": _try, "var": _var, "let": _let, "const": _const,
-                      "while": _while, "with": _with,
-                      "null": _null, "true": _true, "false": _false, "new": _new, "in": _in,
-                      "instanceof": {keyword: "instanceof", binop: 7, beforeExpr: true}, "this": _this,
-                      "typeof": {keyword: "typeof", prefix: true, beforeExpr: true},
-                      "void": {keyword: "void", prefix: true, beforeExpr: true},
-                      "delete": {keyword: "delete", prefix: true, beforeExpr: true},
-                      "class": _class, "extends": _extends,
-                      "export": _export, "import": _import, "yield": _yield};
+  var keywordTypes = {};
 
-  // Punctuation token types. Again, the `type` property is purely for debugging.
+  // Succinct definitions of keyword token types
+  function kw(name, beforeExpr, kind, binop) {
+    keywordTypes[name] = tt["_" + name] =
+       new TokenType(name, beforeExpr, binop, kind, name);
+  };
 
-  var _bracketL = {type: "[", beforeExpr: true}, _bracketR = {type: "]"}, _braceL = {type: "{", beforeExpr: true};
-  var _braceR = {type: "}"}, _parenL = {type: "(", beforeExpr: true}, _parenR = {type: ")"};
-  var _comma = {type: ",", beforeExpr: true}, _semi = {type: ";", beforeExpr: true};
-  var _colon = {type: ":", beforeExpr: true}, _dot = {type: "."}, _question = {type: "?", beforeExpr: true};
-  var _arrow = {type: "=>", beforeExpr: true}, _template = {type: "template"};
-  var _ellipsis = {type: "...", beforeExpr: true};
-  var _backQuote = {type: "`"}, _dollarBraceL = {type: "${", beforeExpr: true};
-
-  // Operators. These carry several kinds of properties to help the
-  // parser use them properly (the presence of these properties is
-  // what categorizes them as operators).
-  //
-  // `binop`, when present, specifies that this operator is a binary
-  // operator, and will refer to its precedence.
-  //
-  // `prefix` and `postfix` mark the operator as a prefix or postfix
-  // unary operator. `isUpdate` specifies that the node produced by
-  // the operator should be of type UpdateExpression rather than
-  // simply UnaryExpression (`++` and `--`).
-  //
-  // `isAssign` marks all of `=`, `+=`, `-=` etcetera, which act as
-  // binary operators with a very low precedence, that should result
-  // in AssignmentExpression nodes.
-
-  var _slash = {binop: 10, beforeExpr: true}, _eq = {isAssign: true, beforeExpr: true};
-  var _assign = {isAssign: true, beforeExpr: true};
-  var _incDec = {postfix: true, prefix: true, isUpdate: true}, _prefix = {prefix: true, beforeExpr: true};
-  var _logicalOR = {binop: 1, beforeExpr: true};
-  var _logicalAND = {binop: 2, beforeExpr: true};
-  var _bitwiseOR = {binop: 3, beforeExpr: true};
-  var _bitwiseXOR = {binop: 4, beforeExpr: true};
-  var _bitwiseAND = {binop: 5, beforeExpr: true};
-  var _equality = {binop: 6, beforeExpr: true};
-  var _relational = {binop: 7, beforeExpr: true};
-  var _bitShift = {binop: 8, beforeExpr: true};
-  var _plusMin = {binop: 9, prefix: true, beforeExpr: true};
-  var _modulo = {binop: 10, beforeExpr: true};
-
-  // '*' may be multiply or have special meaning in ES6
-  var _star = {binop: 10, beforeExpr: true};
-
-  // Provide access to the token types for external users of the
-  // tokenizer.
-
-  exports.tokTypes = {bracketL: _bracketL, bracketR: _bracketR, braceL: _braceL, braceR: _braceR,
-                      parenL: _parenL, parenR: _parenR, comma: _comma, semi: _semi, colon: _colon,
-                      dot: _dot, ellipsis: _ellipsis, question: _question, slash: _slash, eq: _eq,
-                      name: _name, eof: _eof, num: _num, regexp: _regexp, string: _string,
-                      arrow: _arrow, template: _template, star: _star, assign: _assign,
-                      backQuote: _backQuote, dollarBraceL: _dollarBraceL};
-  for (var kw in keywordTypes) exports.tokTypes["_" + kw] = keywordTypes[kw];
+  kw("break"),
+  kw("case", true),
+  kw("catch"),
+  kw("continue"),
+  kw("debugger"),
+  kw("default"),
+  kw("do", false, "loop"),
+  kw("else", true),
+  kw("finally"),
+  kw("for", false, "loop"),
+  kw("function"),
+  kw("if"),
+  kw("return", true),
+  kw("switch");
+  kw("throw", true),
+  kw("try"),
+  kw("var"),
+  kw("let");
+  kw("const");
+  kw("while", false, "loop");
+  kw("with");
+  kw("new", true);
+  kw("this");
+  kw("class");
+  kw("extends", true);
+  kw("export");
+  kw("import");
+  kw("yield", true);
+  kw("null", false, null, null, null);
+  kw("true", false, null, null, true);
+  kw("false", false, null, null, false);
+  kw("in", true, null, 7);
+  kw("instanceof", true, null, 7);
+  kw("typeof", true, "prefix");
+  kw("void", true, "prefix");
+  kw("delete", true, "prefix");
 
   // This is a trick taken from Esprima. It turns out that, on
   // non-Chrome browsers, to check whether a string is in a set, a
@@ -551,7 +567,7 @@
 
     // Properties of the current token:
     // Its type
-    this.type = _eof;
+    this.type = tt.eof;
     // For tokens that include more information than their type, the value
     this.value = null;
     // Its start and end offset
@@ -602,7 +618,7 @@
 
   pp.setStrict = function(strict) {
     this.strict = strict;
-    if (this.type !== _num && this.type !== _string) return;
+    if (this.type !== tt.num && this.type !== tt.string) return;
     this.pos = this.start;
     if (this.options.locations) {
       while (this.pos < this.lineStart) {
@@ -626,7 +642,7 @@
 
     this.start = this.pos;
     if (this.options.locations) this.startLoc = this.curPosition();
-    if (this.pos >= this.input.length) return this.finishToken(_eof);
+    if (this.pos >= this.input.length) return this.finishToken(tt.eof);
 
     if (inTemplate) return this.readTmplToken();
 
@@ -733,13 +749,13 @@
 
   pp.braceIsBlock = function(prevType) {
     var parent;
-    if (prevType === _colon && (parent = this.curTokContext()).token == "{")
+    if (prevType === tt.colon && (parent = this.curTokContext()).token == "{")
       return !parent.isExpr;
-    if (prevType === _return)
+    if (prevType === tt._return)
       return newline.test(this.input.slice(this.lastTokEnd, this.start));
-    if (prevType === _else || prevType === _semi || prevType === _eof)
+    if (prevType === tt._else || prevType === tt.semi || prevType === tt.eof)
       return true;
-    if (prevType == _braceL)
+    if (prevType == tt.braceL)
       return this.curTokContext() === b_stat;
     return !this.exprAllowed;
   };
@@ -757,7 +773,7 @@
     this.value = val;
 
     // Update context info
-    if (type === _parenR || type === _braceR) {
+    if (type === tt.parenR || type === tt.braceR) {
       var out = this.context.pop();
       if (out === b_stat && this.curTokContext() === f_expr) {
         this.context.pop();
@@ -765,26 +781,26 @@
       } else if (out !== b_tmpl) {
         this.exprAllowed = !(out && out.isExpr);
       }
-    } else if (type === _braceL) {
+    } else if (type === tt.braceL) {
       this.context.push(this.braceIsBlock(prevType) ? b_stat : b_expr);
       this.exprAllowed = true;
-    } else if (type === _dollarBraceL) {
+    } else if (type === tt.dollarBraceL) {
       this.context.push(b_tmpl);
       this.exprAllowed = true;
-    } else if (type == _parenL) {
-      var statementParens = prevType === _if || prevType === _for || prevType === _with || prevType === _while;
+    } else if (type == tt.parenL) {
+      var statementParens = prevType === tt._if || prevType === tt._for || prevType === tt._with || prevType === tt._while;
       this.context.push(statementParens ? p_stat : p_expr);
       this.exprAllowed = true;
-    } else if (type == _incDec) {
+    } else if (type == tt.incDec) {
       // tokExprAllowed stays unchanged
-    } else if (type.keyword && prevType == _dot) {
+    } else if (type.keyword && prevType == tt.dot) {
       this.exprAllowed = false;
-    } else if (type == _function) {
+    } else if (type == tt._function) {
       if (this.curTokContext() !== b_stat) {
         this.context.push(f_expr);
       }
       this.exprAllowed = false;
-    } else if (type === _backQuote) {
+    } else if (type === tt.backQuote) {
       if (this.curTokContext() === q_tmpl)
         this.context.pop();
       else
@@ -810,37 +826,37 @@
     var next2 = this.input.charCodeAt(this.pos + 2);
     if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) { // 46 = dot '.'
       this.pos += 3;
-      return this.finishToken(_ellipsis);
+      return this.finishToken(tt.ellipsis);
     } else {
       ++this.pos;
-      return this.finishToken(_dot);
+      return this.finishToken(tt.dot);
     }
   };
 
   pp.readToken_slash = function() { // '/'
     var next = this.input.charCodeAt(this.pos + 1);
     if (this.exprAllowed) {++this.pos; return this.readRegexp();}
-    if (next === 61) return this.finishOp(_assign, 2);
-    return this.finishOp(_slash, 1);
+    if (next === 61) return this.finishOp(tt.assign, 2);
+    return this.finishOp(tt.slash, 1);
   };
 
   pp.readToken_mult_modulo = function(code) { // '%*'
     var next = this.input.charCodeAt(this.pos + 1);
-    if (next === 61) return this.finishOp(_assign, 2);
-    return this.finishOp(code === 42 ? _star : _modulo, 1);
+    if (next === 61) return this.finishOp(tt.assign, 2);
+    return this.finishOp(code === 42 ? tt.star : tt.modulo, 1);
   };
 
   pp.readToken_pipe_amp = function(code) { // '|&'
     var next = this.input.charCodeAt(this.pos + 1);
-    if (next === code) return this.finishOp(code === 124 ? _logicalOR : _logicalAND, 2);
-    if (next === 61) return this.finishOp(_assign, 2);
-    return this.finishOp(code === 124 ? _bitwiseOR : _bitwiseAND, 1);
+    if (next === code) return this.finishOp(code === 124 ? tt.logicalOR : tt.logicalAND, 2);
+    if (next === 61) return this.finishOp(tt.assign, 2);
+    return this.finishOp(code === 124 ? tt.bitwiseOR : tt.bitwiseAND, 1);
   };
 
   pp.readToken_caret = function() { // '^'
     var next = this.input.charCodeAt(this.pos + 1);
-    if (next === 61) return this.finishOp(_assign, 2);
-    return this.finishOp(_bitwiseXOR, 1);
+    if (next === 61) return this.finishOp(tt.assign, 2);
+    return this.finishOp(tt.bitwiseXOR, 1);
   };
 
   pp.readToken_plus_min = function(code) { // '+-'
@@ -853,10 +869,10 @@
         this.skipSpace();
         return this.readToken();
       }
-      return this.finishOp(_incDec, 2);
+      return this.finishOp(tt.incDec, 2);
     }
-    if (next === 61) return this.finishOp(_assign, 2);
-    return this.finishOp(_plusMin, 1);
+    if (next === 61) return this.finishOp(tt.assign, 2);
+    return this.finishOp(tt.plusMin, 1);
   };
 
   pp.readToken_lt_gt = function(code) { // '<>'
@@ -864,8 +880,8 @@
     var size = 1;
     if (next === code) {
       size = code === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
-      if (this.input.charCodeAt(this.pos + size) === 61) return this.finishOp(_assign, size + 1);
-      return this.finishOp(_bitShift, size);
+      if (this.input.charCodeAt(this.pos + size) === 61) return this.finishOp(tt.assign, size + 1);
+      return this.finishOp(tt.bitShift, size);
     }
     if (next == 33 && code == 60 && this.input.charCodeAt(this.pos + 2) == 45 &&
         this.input.charCodeAt(this.pos + 3) == 45) {
@@ -876,17 +892,17 @@
     }
     if (next === 61)
       size = this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2;
-    return this.finishOp(_relational, size);
+    return this.finishOp(tt.relational, size);
   };
 
-  pp.readToken_eq_excl = function(code) { // '=!', '=>'
+  pp.readToken_eq_excl = function(code) { // '=!'
     var next = this.input.charCodeAt(this.pos + 1);
-    if (next === 61) return this.finishOp(_equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+    if (next === 61) return this.finishOp(tt.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
     if (code === 61 && next === 62 && this.options.ecmaVersion >= 6) { // '=>'
       this.pos += 2;
-      return this.finishToken(_arrow);
+      return this.finishToken(tt.arrow);
     }
-    return this.finishOp(code === 61 ? _eq : _prefix, 1);
+    return this.finishOp(code === 61 ? tt.eq : tt.prefix, 1);
   };
 
   pp.getTokenFromCode = function(code) {
@@ -897,21 +913,21 @@
       return this.readToken_dot();
 
     // Punctuation tokens.
-    case 40: ++this.pos; return this.finishToken(_parenL);
-    case 41: ++this.pos; return this.finishToken(_parenR);
-    case 59: ++this.pos; return this.finishToken(_semi);
-    case 44: ++this.pos; return this.finishToken(_comma);
-    case 91: ++this.pos; return this.finishToken(_bracketL);
-    case 93: ++this.pos; return this.finishToken(_bracketR);
-    case 123: ++this.pos; return this.finishToken(_braceL);
-    case 125: ++this.pos; return this.finishToken(_braceR);
-    case 58: ++this.pos; return this.finishToken(_colon);
-    case 63: ++this.pos; return this.finishToken(_question);
+    case 40: ++this.pos; return this.finishToken(tt.parenL);
+    case 41: ++this.pos; return this.finishToken(tt.parenR);
+    case 59: ++this.pos; return this.finishToken(tt.semi);
+    case 44: ++this.pos; return this.finishToken(tt.comma);
+    case 91: ++this.pos; return this.finishToken(tt.bracketL);
+    case 93: ++this.pos; return this.finishToken(tt.bracketR);
+    case 123: ++this.pos; return this.finishToken(tt.braceL);
+    case 125: ++this.pos; return this.finishToken(tt.braceR);
+    case 58: ++this.pos; return this.finishToken(tt.colon);
+    case 63: ++this.pos; return this.finishToken(tt.question);
 
     case 96: // '`'
       if (this.options.ecmaVersion >= 6) {
         ++this.pos;
-        return this.finishToken(_backQuote);
+        return this.finishToken(tt.backQuote);
       } else {
         return false;
       }
@@ -959,7 +975,7 @@
       return this.readToken_eq_excl(code);
 
     case 126: // '~'
-      return this.finishOp(_prefix, 1);
+      return this.finishOp(tt.prefix, 1);
     }
 
     return false;
@@ -1026,7 +1042,7 @@
     } catch (err) {
       value = null;
     }
-    return this.finishToken(_regexp, {pattern: content, flags: mods, value: value});
+    return this.finishToken(tt.regexp, {pattern: content, flags: mods, value: value});
   };
 
   // Read an integer in the given radix. Return null if zero digits
@@ -1055,7 +1071,7 @@
     var val = this.readInt(radix);
     if (val == null) this.raise(this.start + 2, "Expected number in radix " + radix);
     if (isIdentifierStart(this.input.charCodeAt(this.pos))) this.raise(this.pos, "Identifier directly after number");
-    return this.finishToken(_num, val);
+    return this.finishToken(tt.num, val);
   };
 
   // Read an integer, octal integer, or floating-point number.
@@ -1082,7 +1098,7 @@
     else if (!octal || str.length === 1) val = parseInt(str, 10);
     else if (/[89]/.test(str) || this.strict) this.raise(start, "Invalid number");
     else val = parseInt(str, 8);
-    return this.finishToken(_num, val);
+    return this.finishToken(tt.num, val);
   };
 
   // Read a string value, interpreting backslash-escapes.
@@ -1125,7 +1141,7 @@
       }
     }
     out += this.input.slice(chunkStart, this.pos++);
-    return this.finishToken(_string, out);
+    return this.finishToken(tt.string, out);
   };
 
   // Reads template string tokens.
@@ -1136,17 +1152,17 @@
       if (this.pos >= this.input.length) this.raise(this.start, "Unterminated template");
       var ch = this.input.charCodeAt(this.pos);
       if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) { // '`', '${'
-        if (this.pos === this.start && this.type === _template) {
+        if (this.pos === this.start && this.type === tt.template) {
           if (ch === 36) {
             this.pos += 2;
-            return this.finishToken(_dollarBraceL);
+            return this.finishToken(tt.dollarBraceL);
           } else {
             ++this.pos;
-            return this.finishToken(_backQuote);
+            return this.finishToken(tt.backQuote);
           }
         }
         out += this.input.slice(chunkStart, this.pos);
-        return this.finishToken(_template, out);
+        return this.finishToken(tt.template, out);
       }
       if (ch === 92) { // '\'
         out += this.input.slice(chunkStart, this.pos);
@@ -1258,7 +1274,7 @@
 
   pp.readWord = function() {
     var word = this.readWord1();
-    var type = _name;
+    var type = tt.name;
     if (!containsEsc && this.isKeyword(word))
       type = keywordTypes[word];
     return this.finishToken(type, word);
@@ -1365,13 +1381,13 @@
   // Tests whether parsed token is a contextual keyword.
 
   pp.isContextual = function(name) {
-    return this.type === _name && this.value === name;
+    return this.type === tt.name && this.value === name;
   };
 
   // Consumes contextual keyword if possible.
 
   pp.eatContextual = function(name) {
-    return this.value === name && this.eat(_name);
+    return this.value === name && this.eat(tt.name);
   };
 
   // Asserts that following token is given contextual keyword.
@@ -1384,14 +1400,14 @@
 
   pp.canInsertSemicolon = function() {
     return !this.options.strictSemicolons &&
-      (this.type === _eof || this.type === _braceR || newline.test(this.input.slice(this.lastTokEnd, this.start)));
+      (this.type === tt.eof || this.type === tt.braceR || newline.test(this.input.slice(this.lastTokEnd, this.start)));
   };
 
   // Consume a semicolon, or, failing that, see if we are allowed to
   // pretend that there is a semicolon at this position.
 
   pp.semicolon = function() {
-    if (!this.eat(_semi) && !this.canInsertSemicolon()) this.unexpected();
+    if (!this.eat(tt.semi) && !this.canInsertSemicolon()) this.unexpected();
   };
 
   // Expect a token of a given type. If found, consume it, otherwise,
@@ -1498,7 +1514,7 @@
   pp.parseRest = function() {
     var node = this.startNode();
     this.next();
-    node.argument = this.type === _name || this.type === _bracketL ? this.parseBindingAtom() : this.unexpected();
+    node.argument = this.type === tt.name || this.type === tt.bracketL ? this.parseBindingAtom() : this.unexpected();
     return this.finishNode(node, "RestElement");
   };
 
@@ -1507,16 +1523,16 @@
   pp.parseBindingAtom = function() {
     if (this.options.ecmaVersion < 6) return this.parseIdent();
     switch (this.type) {
-      case _name:
+      case tt.name:
         return this.parseIdent();
 
-      case _bracketL:
+      case tt.bracketL:
         var node = this.startNode();
         this.next();
-        node.elements = this.parseBindingList(_bracketR, true);
+        node.elements = this.parseBindingList(tt.bracketR, true);
         return this.finishNode(node, "ArrayPattern");
 
-      case _braceL:
+      case tt.braceL:
         return this.parseObj(true);
 
       default:
@@ -1527,13 +1543,13 @@
   pp.parseBindingList = function(close, allowEmpty) {
     var elts = [], first = true;
     while (!this.eat(close)) {
-      first ? first = false : this.expect(_comma);
-      if (this.type === _ellipsis) {
+      first ? first = false : this.expect(tt.comma);
+      if (this.type === tt.ellipsis) {
         elts.push(this.parseRest());
         this.expect(close);
         break;
       }
-      elts.push(allowEmpty && this.type === _comma ? null : this.parseMaybeDefault());
+      elts.push(allowEmpty && this.type === tt.comma ? null : this.parseMaybeDefault());
     }
     return elts;
   };
@@ -1543,7 +1559,7 @@
   pp.parseMaybeDefault = function(startPos, left) {
     startPos = startPos || this.currentPos();
     left = left || this.parseBindingAtom();
-    if (!this.eat(_eq)) return left;
+    if (!this.eat(tt.eq)) return left;
     var node = this.startNodeAt(startPos);
     node.operator = "=";
     node.left = left;
@@ -1659,7 +1675,7 @@
   pp.parseTopLevel = function(node) {
     var first = true;
     if (!node.body) node.body = [];
-    while (this.type !== _eof) {
+    while (this.type !== tt.eof) {
       var stmt = this.parseStatement(true, true);
       node.body.push(stmt);
       if (first && this.isUseStrict(stmt)) this.setStrict(true);
@@ -1687,32 +1703,32 @@
     // complexity.
 
     switch (starttype) {
-    case _break: case _continue: return this.parseBreakContinueStatement(node, starttype.keyword);
-    case _debugger: return this.parseDebuggerStatement(node);
-    case _do: return this.parseDoStatement(node);
-    case _for: return this.parseForStatement(node);
-    case _function:
+    case tt._break: case tt._continue: return this.parseBreakContinueStatement(node, starttype.keyword);
+    case tt._debugger: return this.parseDebuggerStatement(node);
+    case tt._do: return this.parseDoStatement(node);
+    case tt._for: return this.parseForStatement(node);
+    case tt._function:
       if (!declaration && this.options.ecmaVersion >= 6) this.unexpected();
       return this.parseFunctionStatement(node);
-    case _class:
+    case tt._class:
       if (!declaration) this.unexpected();
       return this.parseClass(node, true);
-    case _if: return this.parseIfStatement(node);
-    case _return: return this.parseReturnStatement(node);
-    case _switch: return this.parseSwitchStatement(node);
-    case _throw: return this.parseThrowStatement(node);
-    case _try: return this.parseTryStatement(node);
-    case _let: case _const: if (!declaration) this.unexpected(); // NOTE: falls through to _var
-    case _var: return this.parseVarStatement(node, starttype.keyword);
-    case _while: return this.parseWhileStatement(node);
-    case _with: return this.parseWithStatement(node);
-    case _braceL: return this.parseBlock(); // no point creating a function for this
-    case _semi: return this.parseEmptyStatement(node);
-    case _export:
-    case _import:
+    case tt._if: return this.parseIfStatement(node);
+    case tt._return: return this.parseReturnStatement(node);
+    case tt._switch: return this.parseSwitchStatement(node);
+    case tt._throw: return this.parseThrowStatement(node);
+    case tt._try: return this.parseTryStatement(node);
+    case tt._let: case tt._const: if (!declaration) this.unexpected(); // NOTE: falls through to _var
+    case tt._var: return this.parseVarStatement(node, starttype.keyword);
+    case tt._while: return this.parseWhileStatement(node);
+    case tt._with: return this.parseWithStatement(node);
+    case tt.braceL: return this.parseBlock(); // no point creating a function for this
+    case tt.semi: return this.parseEmptyStatement(node);
+    case tt._export:
+    case tt._import:
       if (!topLevel && !this.options.allowImportExportEverywhere)
         this.raise(this.start, "'import' and 'export' may only appear at the top level");
-      return starttype === _import ? this.parseImport(node) : this.parseExport(node);
+      return starttype === tt._import ? this.parseImport(node) : this.parseExport(node);
 
       // If the statement does not start with a statement keyword or a
       // brace, it's an ExpressionStatement or LabeledStatement. We
@@ -1721,7 +1737,7 @@
       // Identifier node, we switch to interpreting it as a label.
     default:
       var maybeName = this.value, expr = this.parseExpression();
-      if (starttype === _name && expr.type === "Identifier" && this.eat(_colon))
+      if (starttype === tt.name && expr.type === "Identifier" && this.eat(tt.colon))
         return this.parseLabeledStatement(node, maybeName, expr);
       else return this.parseExpressionStatement(node, expr);
     }
@@ -1730,8 +1746,8 @@
   pp.parseBreakContinueStatement = function(node, keyword) {
     var isBreak = keyword == "break";
     this.next();
-    if (this.eat(_semi) || this.canInsertSemicolon()) node.label = null;
-    else if (this.type !== _name) this.unexpected();
+    if (this.eat(tt.semi) || this.canInsertSemicolon()) node.label = null;
+    else if (this.type !== tt.name) this.unexpected();
     else {
       node.label = this.parseIdent();
       this.semicolon();
@@ -1761,10 +1777,10 @@
     this.labels.push(loopLabel);
     node.body = this.parseStatement(false);
     this.labels.pop();
-    this.expect(_while);
+    this.expect(tt._while);
     node.test = this.parseParenExpression();
     if (this.options.ecmaVersion >= 6)
-      this.eat(_semi);
+      this.eat(tt.semi);
     else
       this.semicolon();
     return this.finishNode(node, "DoWhileStatement");
@@ -1781,21 +1797,21 @@
   pp.parseForStatement = function(node) {
     this.next();
     this.labels.push(loopLabel);
-    this.expect(_parenL);
-    if (this.type === _semi) return this.parseFor(node, null);
-    if (this.type === _var || this.type === _let) {
-      var init = this.startNode(), varKind = this.type.keyword, isLet = this.type === _let;
+    this.expect(tt.parenL);
+    if (this.type === tt.semi) return this.parseFor(node, null);
+    if (this.type === tt._var || this.type === tt._let) {
+      var init = this.startNode(), varKind = this.type.keyword, isLet = this.type === tt._let;
       this.next();
       this.parseVar(init, true, varKind);
       this.finishNode(init, "VariableDeclaration");
-      if ((this.type === _in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) && init.declarations.length === 1 &&
+      if ((this.type === tt._in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) && init.declarations.length === 1 &&
           !(isLet && init.declarations[0].init))
         return this.parseForIn(node, init);
       return this.parseFor(node, init);
     }
     var refShorthandDefaultPos = {start: 0};
     var init = this.parseExpression(true, refShorthandDefaultPos);
-    if (this.type === _in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+    if (this.type === tt._in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
       this.toAssignable(init);
       this.checkLVal(init);
       return this.parseForIn(node, init);
@@ -1814,7 +1830,7 @@
     this.next();
     node.test = this.parseParenExpression();
     node.consequent = this.parseStatement(false);
-    node.alternate = this.eat(_else) ? this.parseStatement(false) : null;
+    node.alternate = this.eat(tt._else) ? this.parseStatement(false) : null;
     return this.finishNode(node, "IfStatement");
   };
 
@@ -1827,7 +1843,7 @@
     // optional arguments, we eagerly look for a semicolon or the
     // possibility to insert one.
 
-    if (this.eat(_semi) || this.canInsertSemicolon()) node.argument = null;
+    if (this.eat(tt.semi) || this.canInsertSemicolon()) node.argument = null;
     else { node.argument = this.parseExpression(); this.semicolon(); }
     return this.finishNode(node, "ReturnStatement");
   };
@@ -1836,16 +1852,16 @@
     this.next();
     node.discriminant = this.parseParenExpression();
     node.cases = [];
-    this.expect(_braceL);
+    this.expect(tt.braceL);
     this.labels.push(switchLabel);
 
     // Statements under must be grouped (by label) in SwitchCase
     // nodes. `cur` is used to keep the node that we are currently
     // adding statements to.
 
-    for (var cur, sawDefault; this.type != _braceR;) {
-      if (this.type === _case || this.type === _default) {
-        var isCase = this.type === _case;
+    for (var cur, sawDefault; this.type != tt.braceR;) {
+      if (this.type === tt._case || this.type === tt._default) {
+        var isCase = this.type === tt._case;
         if (cur) this.finishNode(cur, "SwitchCase");
         node.cases.push(cur = this.startNode());
         cur.consequent = [];
@@ -1855,7 +1871,7 @@
           if (sawDefault) this.raise(this.lastTokStart, "Multiple default clauses"); sawDefault = true;
           cur.test = null;
         }
-        this.expect(_colon);
+        this.expect(tt.colon);
       } else {
         if (!cur) this.unexpected();
         cur.consequent.push(this.parseStatement(true));
@@ -1880,19 +1896,19 @@
     this.next();
     node.block = this.parseBlock();
     node.handler = null;
-    if (this.type === _catch) {
+    if (this.type === tt._catch) {
       var clause = this.startNode();
       this.next();
-      this.expect(_parenL);
+      this.expect(tt.parenL);
       clause.param = this.parseBindingAtom();
       this.checkLVal(clause.param, true);
-      this.expect(_parenR);
+      this.expect(tt.parenR);
       clause.guard = null;
       clause.body = this.parseBlock();
       node.handler = this.finishNode(clause, "CatchClause");
     }
     node.guardedHandlers = empty;
-    node.finalizer = this.eat(_finally) ? this.parseBlock() : null;
+    node.finalizer = this.eat(tt._finally) ? this.parseBlock() : null;
     if (!node.handler && !node.finalizer)
       this.raise(node.start, "Missing catch or finally clause");
     return this.finishNode(node, "TryStatement");
@@ -1930,7 +1946,7 @@
   pp.parseLabeledStatement = function(node, maybeName, expr) {
     for (var i = 0; i < this.labels.length; ++i)
       if (this.labels[i].name === maybeName) this.raise(expr.start, "Label '" + maybeName + "' is already declared");
-    var kind = this.type.isLoop ? "loop" : this.type === _switch ? "switch" : null;
+    var kind = this.type.isLoop ? "loop" : this.type === tt._switch ? "switch" : null;
     this.labels.push({name: maybeName, kind: kind});
     node.body = this.parseStatement(true);
     this.labels.pop();
@@ -1948,9 +1964,9 @@
   // parentheses around their expression.
 
   pp.parseParenExpression = function() {
-    this.expect(_parenL);
+    this.expect(tt.parenL);
     var val = this.parseExpression();
-    this.expect(_parenR);
+    this.expect(tt.parenR);
     return val;
   };
 
@@ -1961,8 +1977,8 @@
   pp.parseBlock = function(allowStrict) {
     var node = this.startNode(), first = true, oldStrict;
     node.body = [];
-    this.expect(_braceL);
-    while (!this.eat(_braceR)) {
+    this.expect(tt.braceL);
+    while (!this.eat(tt.braceR)) {
       var stmt = this.parseStatement(true);
       node.body.push(stmt);
       if (first && allowStrict && this.isUseStrict(stmt)) {
@@ -1981,11 +1997,11 @@
 
   pp.parseFor = function(node, init) {
     node.init = init;
-    this.expect(_semi);
-    node.test = this.type === _semi ? null : this.parseExpression();
-    this.expect(_semi);
-    node.update = this.type === _parenR ? null : this.parseExpression();
-    this.expect(_parenR);
+    this.expect(tt.semi);
+    node.test = this.type === tt.semi ? null : this.parseExpression();
+    this.expect(tt.semi);
+    node.update = this.type === tt.parenR ? null : this.parseExpression();
+    this.expect(tt.parenR);
     node.body = this.parseStatement(false);
     this.labels.pop();
     return this.finishNode(node, "ForStatement");
@@ -1995,11 +2011,11 @@
   // same from parser's perspective.
 
   pp.parseForIn = function(node, init) {
-    var type = this.type === _in ? "ForInStatement" : "ForOfStatement";
+    var type = this.type === tt._in ? "ForInStatement" : "ForOfStatement";
     this.next();
     node.left = init;
     node.right = this.parseExpression();
-    this.expect(_parenR);
+    this.expect(tt.parenR);
     node.body = this.parseStatement(false);
     this.labels.pop();
     return this.finishNode(node, type);
@@ -2014,9 +2030,9 @@
       var decl = this.startNode();
       decl.id = this.parseBindingAtom();
       this.checkLVal(decl.id, true);
-      decl.init = this.eat(_eq) ? this.parseMaybeAssign(noIn) : (kind === _const.keyword ? this.unexpected() : null);
+      decl.init = this.eat(tt.eq) ? this.parseMaybeAssign(noIn) : (kind === tt._const.keyword ? this.unexpected() : null);
       node.declarations.push(this.finishNode(decl, "VariableDeclarator"));
-      if (!this.eat(_comma)) break;
+      if (!this.eat(tt.comma)) break;
     }
     return node;
   };
@@ -2039,10 +2055,10 @@
   pp.parseExpression = function(noIn, refShorthandDefaultPos) {
     var start = this.currentPos();
     var expr = this.parseMaybeAssign(noIn, refShorthandDefaultPos);
-    if (this.type === _comma) {
+    if (this.type === tt.comma) {
       var node = this.startNodeAt(start);
       node.expressions = [expr];
-      while (this.eat(_comma)) node.expressions.push(this.parseMaybeAssign(noIn, refShorthandDefaultPos));
+      while (this.eat(tt.comma)) node.expressions.push(this.parseMaybeAssign(noIn, refShorthandDefaultPos));
       return this.finishNode(node, "SequenceExpression");
     }
     return expr;
@@ -2064,7 +2080,7 @@
     if (this.type.isAssign) {
       var node = this.startNodeAt(start);
       node.operator = this.value;
-      node.left = this.type === _eq ? this.toAssignable(left) : left;
+      node.left = this.type === tt.eq ? this.toAssignable(left) : left;
       refShorthandDefaultPos.start = 0; // reset because shorthand default was used correctly
       this.checkLVal(left);
       this.next();
@@ -2082,11 +2098,11 @@
     var start = this.currentPos();
     var expr = this.parseExprOps(noIn, refShorthandDefaultPos);
     if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr;
-    if (this.eat(_question)) {
+    if (this.eat(tt.question)) {
       var node = this.startNodeAt(start);
       node.test = expr;
       node.consequent = this.parseMaybeAssign();
-      this.expect(_colon);
+      this.expect(tt.colon);
       node.alternate = this.parseMaybeAssign(noIn);
       return this.finishNode(node, "ConditionalExpression");
     }
@@ -2110,7 +2126,7 @@
 
   pp.parseExprOp = function(left, leftStart, minPrec, noIn) {
     var prec = this.type.binop;
-    if (prec != null && (!noIn || this.type !== _in)) {
+    if (prec != null && (!noIn || this.type !== tt._in)) {
       if (prec > minPrec) {
         var node = this.startNodeAt(leftStart);
         node.left = left;
@@ -2119,7 +2135,7 @@
         this.next();
         var start = this.currentPos();
         node.right = this.parseExprOp(this.parseMaybeUnary(), start, prec, noIn);
-        this.finishNode(node, (op === _logicalOR || op === _logicalAND) ? "LogicalExpression" : "BinaryExpression");
+        this.finishNode(node, (op === tt.logicalOR || op === tt.logicalAND) ? "LogicalExpression" : "BinaryExpression");
         return this.parseExprOp(node, leftStart, minPrec, noIn);
       }
     }
@@ -2130,7 +2146,7 @@
 
   pp.parseMaybeUnary = function(refShorthandDefaultPos) {
     if (this.type.prefix) {
-      var node = this.startNode(), update = this.type.isUpdate;
+      var node = this.startNode(), update = this.type === tt.incDec;
       node.operator = this.value;
       node.prefix = true;
       this.next();
@@ -2167,25 +2183,25 @@
   };
 
   pp.parseSubscripts = function(base, start, noCalls) {
-    if (this.eat(_dot)) {
+    if (this.eat(tt.dot)) {
       var node = this.startNodeAt(start);
       node.object = base;
       node.property = this.parseIdent(true);
       node.computed = false;
       return this.parseSubscripts(this.finishNode(node, "MemberExpression"), start, noCalls);
-    } else if (this.eat(_bracketL)) {
+    } else if (this.eat(tt.bracketL)) {
       var node = this.startNodeAt(start);
       node.object = base;
       node.property = this.parseExpression();
       node.computed = true;
-      this.expect(_bracketR);
+      this.expect(tt.bracketR);
       return this.parseSubscripts(this.finishNode(node, "MemberExpression"), start, noCalls);
-    } else if (!noCalls && this.eat(_parenL)) {
+    } else if (!noCalls && this.eat(tt.parenL)) {
       var node = this.startNodeAt(start);
       node.callee = base;
-      node.arguments = this.parseExprList(_parenR, false);
+      node.arguments = this.parseExprList(tt.parenR, false);
       return this.parseSubscripts(this.finishNode(node, "CallExpression"), start, noCalls);
-    } else if (this.type === _backQuote) {
+    } else if (this.type === tt.backQuote) {
       var node = this.startNodeAt(start);
       node.tag = base;
       node.quasi = this.parseTemplate();
@@ -2200,23 +2216,23 @@
 
   pp.parseExprAtom = function(refShorthandDefaultPos) {
     switch (this.type) {
-    case _this:
+    case tt._this:
       var node = this.startNode();
       this.next();
       return this.finishNode(node, "ThisExpression");
 
-    case _yield:
+    case tt._yield:
       if (this.inGenerator) return this.parseYield();
 
-    case _name:
+    case tt.name:
       var start = this.currentPos();
-      var id = this.parseIdent(this.type !== _name);
-      if (!this.canInsertSemicolon() && this.eat(_arrow)) {
+      var id = this.parseIdent(this.type !== tt.name);
+      if (!this.canInsertSemicolon() && this.eat(tt.arrow)) {
         return this.parseArrowExpression(this.startNodeAt(start), [id]);
       }
       return id;
 
-    case _regexp:
+    case tt.regexp:
       var node = this.startNode();
       node.regex = {pattern: this.value.pattern, flags: this.value.flags};
       node.value = this.value.value;
@@ -2224,48 +2240,48 @@
       this.next();
       return this.finishNode(node, "Literal");
 
-    case _num: case _string:
+    case tt.num: case tt.string:
       var node = this.startNode();
       node.value = this.value;
       node.raw = this.input.slice(this.start, this.end);
       this.next();
       return this.finishNode(node, "Literal");
 
-    case _null: case _true: case _false:
+    case tt._null: case tt._true: case tt._false:
       var node = this.startNode();
-      node.value = this.type.atomValue;
+      node.value = this.type === tt._null ? null : this.type === tt._true;
       node.raw = this.type.keyword;
       this.next();
       return this.finishNode(node, "Literal");
 
-    case _parenL:
+    case tt.parenL:
       return this.parseParenAndDistinguishExpression();
 
-    case _bracketL:
+    case tt.bracketL:
       var node = this.startNode();
       this.next();
       // check whether this is array comprehension or regular array
-      if (this.options.ecmaVersion >= 7 && this.type === _for) {
+      if (this.options.ecmaVersion >= 7 && this.type === tt._for) {
         return this.parseComprehension(node, false);
       }
-      node.elements = this.parseExprList(_bracketR, true, true, refShorthandDefaultPos);
+      node.elements = this.parseExprList(tt.bracketR, true, true, refShorthandDefaultPos);
       return this.finishNode(node, "ArrayExpression");
 
-    case _braceL:
+    case tt.braceL:
       return this.parseObj(false, refShorthandDefaultPos);
 
-    case _function:
+    case tt._function:
       var node = this.startNode();
       this.next();
       return this.parseFunction(node, false);
 
-    case _class:
+    case tt._class:
       return this.parseClass(this.startNode(), false);
 
-    case _new:
+    case tt._new:
       return this.parseNew();
 
-    case _backQuote:
+    case tt.backQuote:
       return this.parseTemplate();
 
     default:
@@ -2278,29 +2294,29 @@
     if (this.options.ecmaVersion >= 6) {
       this.next();
 
-      if (this.options.ecmaVersion >= 7 && this.type === _for) {
+      if (this.options.ecmaVersion >= 7 && this.type === tt._for) {
         return this.parseComprehension(this.startNodeAt(start), true);
       }
 
       var innerStart = this.currentPos(), exprList = [], first = true;
       var refShorthandDefaultPos = {start: 0}, spreadStart, innerParenStart;
-      while (this.type !== _parenR) {
-        first ? first = false : this.expect(_comma);
-        if (this.type === _ellipsis) {
+      while (this.type !== tt.parenR) {
+        first ? first = false : this.expect(tt.comma);
+        if (this.type === tt.ellipsis) {
           spreadStart = this.start;
           exprList.push(this.parseRest());
           break;
         } else {
-          if (this.type === _parenL && !innerParenStart) {
+          if (this.type === tt.parenL && !innerParenStart) {
             innerParenStart = this.start;
           }
           exprList.push(this.parseMaybeAssign(false, refShorthandDefaultPos));
         }
       }
       var innerEnd = this.currentPos();
-      this.expect(_parenR);
+      this.expect(tt.parenR);
 
-      if (!this.canInsertSemicolon() && this.eat(_arrow)) {
+      if (!this.canInsertSemicolon() && this.eat(tt.arrow)) {
         if (innerParenStart) this.unexpected(innerParenStart);
         return this.parseArrowExpression(this.startNodeAt(start), exprList);
       }
@@ -2338,7 +2354,7 @@
     this.next();
     var start = this.currentPos();
     node.callee = this.parseSubscripts(this.parseExprAtom(), start, true);
-    if (this.eat(_parenL)) node.arguments = this.parseExprList(_parenR, false);
+    if (this.eat(tt.parenL)) node.arguments = this.parseExprList(tt.parenR, false);
     else node.arguments = empty;
     return this.finishNode(node, "NewExpression");
   };
@@ -2352,7 +2368,7 @@
       cooked: this.value
     };
     this.next();
-    elem.tail = this.type === _backQuote;
+    elem.tail = this.type === tt.backQuote;
     return this.finishNode(elem, "TemplateElement");
   };
 
@@ -2363,9 +2379,9 @@
     var curElt = this.parseTemplateElement();
     node.quasis = [curElt];
     while (!curElt.tail) {
-      this.expect(_dollarBraceL);
+      this.expect(tt.dollarBraceL);
       node.expressions.push(this.parseExpression());
-      this.expect(_braceR);
+      this.expect(tt.braceR);
       node.quasis.push(curElt = this.parseTemplateElement());
     }
     this.next();
@@ -2378,10 +2394,10 @@
     var node = this.startNode(), first = true, propHash = {};
     node.properties = [];
     this.next();
-    while (!this.eat(_braceR)) {
+    while (!this.eat(tt.braceR)) {
       if (!first) {
-        this.expect(_comma);
-        if (this.options.allowTrailingCommas && this.eat(_braceR)) break;
+        this.expect(tt.comma);
+        if (this.options.allowTrailingCommas && this.eat(tt.braceR)) break;
       } else first = false;
 
       var prop = this.startNode(), isGenerator, start;
@@ -2392,21 +2408,21 @@
           start = this.currentPos();
         }
         if (!isPattern) {
-          isGenerator = this.eat(_star);
+          isGenerator = this.eat(tt.star);
         }
       }
       this.parsePropertyName(prop);
-      if (this.eat(_colon)) {
+      if (this.eat(tt.colon)) {
         prop.value = isPattern ? this.parseMaybeDefault() : this.parseMaybeAssign(false, refShorthandDefaultPos);
         prop.kind = "init";
-      } else if (this.options.ecmaVersion >= 6 && this.type === _parenL) {
+      } else if (this.options.ecmaVersion >= 6 && this.type === tt.parenL) {
         if (isPattern) this.unexpected();
         prop.kind = "init";
         prop.method = true;
         prop.value = this.parseMethod(isGenerator);
       } else if (this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" &&
                  (prop.key.name === "get" || prop.key.name === "set") &&
-                 (this.type != _comma && this.type != _braceR)) {
+                 (this.type != tt.comma && this.type != tt.braceR)) {
         if (isGenerator || isPattern) this.unexpected();
         prop.kind = prop.key.name;
         this.parsePropertyName(prop);
@@ -2415,7 +2431,7 @@
         prop.kind = "init";
         if (isPattern) {
           prop.value = this.parseMaybeDefault(start, prop.key);
-        } else if (this.type === _eq && refShorthandDefaultPos) {
+        } else if (this.type === tt.eq && refShorthandDefaultPos) {
           if (!refShorthandDefaultPos.start)
             refShorthandDefaultPos.start = this.start;
           prop.value = this.parseMaybeDefault(start, prop.key);
@@ -2433,16 +2449,16 @@
 
   pp.parsePropertyName = function(prop) {
     if (this.options.ecmaVersion >= 6) {
-      if (this.eat(_bracketL)) {
+      if (this.eat(tt.bracketL)) {
         prop.computed = true;
         prop.key = this.parseExpression();
-        this.expect(_bracketR);
+        this.expect(tt.bracketR);
         return;
       } else {
         prop.computed = false;
       }
     }
-    prop.key = (this.type === _num || this.type === _string) ? this.parseExprAtom() : this.parseIdent(true);
+    prop.key = (this.type === tt.num || this.type === tt.string) ? this.parseExprAtom() : this.parseIdent(true);
   };
 
   // Initialize empty function node.
@@ -2461,13 +2477,13 @@
   pp.parseFunction = function(node, isStatement, allowExpressionBody) {
     this.initFunction(node);
     if (this.options.ecmaVersion >= 6) {
-      node.generator = this.eat(_star);
+      node.generator = this.eat(tt.star);
     }
-    if (isStatement || this.type === _name) {
+    if (isStatement || this.type === tt.name) {
       node.id = this.parseIdent();
     }
-    this.expect(_parenL);
-    node.params = this.parseBindingList(_parenR, false);
+    this.expect(tt.parenL);
+    node.params = this.parseBindingList(tt.parenR, false);
     this.parseFunctionBody(node, allowExpressionBody);
     return this.finishNode(node, isStatement ? "FunctionDeclaration" : "FunctionExpression");
   };
@@ -2477,8 +2493,8 @@
   pp.parseMethod = function(isGenerator) {
     var node = this.startNode();
     this.initFunction(node);
-    this.expect(_parenL);
-    node.params = this.parseBindingList(_parenR, false);
+    this.expect(tt.parenL);
+    node.params = this.parseBindingList(tt.parenR, false);
     var allowExpressionBody;
     if (this.options.ecmaVersion >= 6) {
       node.generator = isGenerator;
@@ -2502,7 +2518,7 @@
   // Parse function body and check parameters.
 
   pp.parseFunctionBody = function(node, allowExpression) {
-    var isExpression = allowExpression && this.type !== _braceL;
+    var isExpression = allowExpression && this.type !== tt.braceL;
 
     if (isExpression) {
       node.body = this.parseMaybeAssign();
@@ -2534,26 +2550,26 @@
 
   pp.parseClass = function(node, isStatement) {
     this.next();
-    node.id = this.type === _name ? this.parseIdent() : isStatement ? this.unexpected() : null;
-    node.superClass = this.eat(_extends) ? this.parseExprSubscripts() : null;
+    node.id = this.type === tt.name ? this.parseIdent() : isStatement ? this.unexpected() : null;
+    node.superClass = this.eat(tt._extends) ? this.parseExprSubscripts() : null;
     var classBody = this.startNode();
     classBody.body = [];
-    this.expect(_braceL);
-    while (!this.eat(_braceR)) {
-      if (this.eat(_semi)) continue;
+    this.expect(tt.braceL);
+    while (!this.eat(tt.braceR)) {
+      if (this.eat(tt.semi)) continue;
       var method = this.startNode();
-      var isGenerator = this.eat(_star);
+      var isGenerator = this.eat(tt.star);
       this.parsePropertyName(method);
-      if (this.type !== _parenL && !method.computed && method.key.type === "Identifier" &&
+      if (this.type !== tt.parenL && !method.computed && method.key.type === "Identifier" &&
           method.key.name === "static") {
         if (isGenerator) this.unexpected();
         method['static'] = true;
-        isGenerator = this.eat(_star);
+        isGenerator = this.eat(tt.star);
         this.parsePropertyName(method);
       } else {
         method['static'] = false;
       }
-      if (this.type !== _parenL && !method.computed && method.key.type === "Identifier" &&
+      if (this.type !== tt.parenL && !method.computed && method.key.type === "Identifier" &&
           (method.key.name === "get" || method.key.name === "set")) {
         if (isGenerator) this.unexpected();
         method.kind = method.key.name;
@@ -2578,14 +2594,14 @@
     var elts = [], first = true;
     while (!this.eat(close)) {
       if (!first) {
-        this.expect(_comma);
+        this.expect(tt.comma);
         if (allowTrailingComma && this.options.allowTrailingCommas && this.eat(close)) break;
       } else first = false;
 
-      if (allowEmpty && this.type === _comma) {
+      if (allowEmpty && this.type === tt.comma) {
         elts.push(null);
       } else {
-        if (this.type === _ellipsis)
+        if (this.type === tt.ellipsis)
           elts.push(this.parseSpread(refShorthandDefaultPos));
         else
           elts.push(this.parseMaybeAssign(false, refShorthandDefaultPos));
@@ -2601,7 +2617,7 @@
   pp.parseIdent = function(liberal) {
     var node = this.startNode();
     if (liberal && this.options.forbidReserved == "everywhere") liberal = false;
-    if (this.type === _name) {
+    if (this.type === tt.name) {
       if (!liberal &&
           (this.options.forbidReserved &&
            (this.options.ecmaVersion === 3 ? isReservedWord3 : isReservedWord5)(this.value) ||
@@ -2623,14 +2639,14 @@
   pp.parseExport = function(node) {
     this.next();
     // export var|const|let|function|class ...;
-    if (this.type === _var || this.type === _const || this.type === _let || this.type === _function || this.type === _class) {
+    if (this.type === tt._var || this.type === tt._const || this.type === tt._let || this.type === tt._function || this.type === tt._class) {
       node.declaration = this.parseStatement(true);
       node['default'] = false;
       node.specifiers = null;
       node.source = null;
     } else
     // export default ...;
-    if (this.eat(_default)) {
+    if (this.eat(tt._default)) {
       var expr = this.parseMaybeAssign();
       if (expr.id) {
         switch (expr.type) {
@@ -2646,12 +2662,12 @@
     } else {
       // export * from '...';
       // export { x, y as z } [from '...'];
-      var isBatch = this.type === _star;
+      var isBatch = this.type === tt.star;
       node.declaration = null;
       node['default'] = false;
       node.specifiers = this.parseExportSpecifiers();
       if (this.eatContextual("from")) {
-        node.source = this.type === _string ? this.parseExprAtom() : this.unexpected();
+        node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected();
       } else {
         if (isBatch) this.unexpected();
         node.source = null;
@@ -2665,22 +2681,22 @@
 
   pp.parseExportSpecifiers = function() {
     var nodes = [], first = true;
-    if (this.type === _star) {
+    if (this.type === tt.star) {
       // export * from '...'
       var node = this.startNode();
       this.next();
       nodes.push(this.finishNode(node, "ExportBatchSpecifier"));
     } else {
       // export { x, y as z } [from '...']
-      this.expect(_braceL);
-      while (!this.eat(_braceR)) {
+      this.expect(tt.braceL);
+      while (!this.eat(tt.braceR)) {
         if (!first) {
-          this.expect(_comma);
-          if (this.options.allowTrailingCommas && this.eat(_braceR)) break;
+          this.expect(tt.comma);
+          if (this.options.allowTrailingCommas && this.eat(tt.braceR)) break;
         } else first = false;
 
         var node = this.startNode();
-        node.id = this.parseIdent(this.type === _default);
+        node.id = this.parseIdent(this.type === tt._default);
         node.name = this.eatContextual("as") ? this.parseIdent(true) : null;
         nodes.push(this.finishNode(node, "ExportSpecifier"));
       }
@@ -2693,14 +2709,14 @@
   pp.parseImport = function(node) {
     this.next();
     // import '...';
-    if (this.type === _string) {
+    if (this.type === tt.string) {
       node.specifiers = [];
       node.source = this.parseExprAtom();
       node.kind = "";
     } else {
       node.specifiers = this.parseImportSpecifiers();
       this.expectContextual("from");
-      node.source = this.type === _string ? this.parseExprAtom() : this.unexpected();
+      node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected();
     }
     this.semicolon();
     return this.finishNode(node, "ImportDeclaration");
@@ -2710,7 +2726,7 @@
 
   pp.parseImportSpecifiers = function() {
     var nodes = [], first = true;
-    if (this.type === _name) {
+    if (this.type === tt.name) {
       // import defaultObj, { x, y as z } from '...'
       var node = this.startNode();
       node.id = this.parseIdent();
@@ -2718,9 +2734,9 @@
       node.name = null;
       node['default'] = true;
       nodes.push(this.finishNode(node, "ImportSpecifier"));
-      if (!this.eat(_comma)) return nodes;
+      if (!this.eat(tt.comma)) return nodes;
     }
-    if (this.type === _star) {
+    if (this.type === tt.star) {
       var node = this.startNode();
       this.next();
       this.expectContextual("as");
@@ -2729,11 +2745,11 @@
       nodes.push(this.finishNode(node, "ImportBatchSpecifier"));
       return nodes;
     }
-    this.expect(_braceL);
-    while (!this.eat(_braceR)) {
+    this.expect(tt.braceL);
+    while (!this.eat(tt.braceR)) {
       if (!first) {
-        this.expect(_comma);
-        if (this.options.allowTrailingCommas && this.eat(_braceR)) break;
+        this.expect(tt.comma);
+        if (this.options.allowTrailingCommas && this.eat(tt.braceR)) break;
       } else first = false;
 
       var node = this.startNode();
@@ -2751,11 +2767,11 @@
   pp.parseYield = function() {
     var node = this.startNode();
     this.next();
-    if (this.eat(_semi) || this.canInsertSemicolon()) {
+    if (this.eat(tt.semi) || this.canInsertSemicolon()) {
       node.delegate = false;
       node.argument = null;
     } else {
-      node.delegate = this.eat(_star);
+      node.delegate = this.eat(tt.star);
       node.argument = this.parseMaybeAssign();
     }
     return this.finishNode(node, "YieldExpression");
@@ -2765,20 +2781,20 @@
 
   pp.parseComprehension = function(node, isGenerator) {
     node.blocks = [];
-    while (this.type === _for) {
+    while (this.type === tt._for) {
       var block = this.startNode();
       this.next();
-      this.expect(_parenL);
+      this.expect(tt.parenL);
       block.left = this.parseBindingAtom();
       this.checkLVal(block.left, true);
       this.expectContextual("of");
       block.right = this.parseExpression();
-      this.expect(_parenR);
+      this.expect(tt.parenR);
       node.blocks.push(this.finishNode(block, "ComprehensionBlock"));
     }
-    node.filter = this.eat(_if) ? this.parseParenExpression() : null;
+    node.filter = this.eat(tt._if) ? this.parseParenExpression() : null;
     node.body = this.parseExpression();
-    this.expect(isGenerator ? _parenR : _bracketR);
+    this.expect(isGenerator ? tt.parenR : tt.bracketR);
     node.generator = isGenerator;
     return this.finishNode(node, "ComprehensionExpression");
   };

--- a/acorn_loose.js
+++ b/acorn_loose.js
@@ -627,7 +627,7 @@
 
   function parseMaybeUnary(noIn) {
     if (token.type.prefix) {
-      var node = startNode(), update = token.type.isUpdate;
+      var node = startNode(), update = token.type === tt.incDec;
       node.operator = token.value;
       node.prefix = true;
       next();
@@ -733,7 +733,7 @@
 
     case tt._null: case tt._true: case tt._false:
       var node = startNode();
-      node.value = token.type.atomValue;
+      node.value = token.type === tt._null ? null : token.type === tt._true;
       node.raw = token.type.keyword;
       next();
       return finishNode(node, "Literal");

--- a/plugin/jsx.js
+++ b/plugin/jsx.js
@@ -1,0 +1,662 @@
+(function(root, mod) {
+  if (typeof exports == "object" && typeof module == "object") return mod(require("../acorn")); // CommonJS
+  if (typeof define == "function" && define.amd) return define(["../acorn"], mod); // AMD
+  mod(root.acorn); // Plain browser env
+})(this, function(acorn) {
+  "use strict";
+
+  var tt = acorn.tokTypes;
+  var tc = acorn.tokContexts;
+
+  tc.j_oTag = new acorn.TokContext("<tag", false);
+  tc.j_cTag = new acorn.TokContext("</tag", false);
+  tc.j_expr = new acorn.TokContext("<tag>...</tag>", true, true);
+
+  tt.jsxName = new acorn.TokenType("jsxName");
+  tt.jsxText = new acorn.TokenType("jsxText", true);
+  tt.jsxTagStart = new acorn.TokenType("jsxTagStart");
+  tt.jsxTagEnd = new acorn.TokenType("jsxTagEnd");
+
+  tt.jsxTagStart.updateContext = function() {
+    this.context.push(tc.j_expr); // treat as beginning of JSX expression
+    this.context.push(tc.j_oTag); // start opening tag context
+    this.exprAllowed = false;
+  };
+  tt.jsxTagEnd.updateContext = function(prevType) {
+    var out = this.context.pop();
+    if (out === tc.j_oTag && prevType === tt.slash || out === tc.j_cTag) {
+      this.context.pop();
+      this.exprAllowed = this.curContext() === tc.j_expr;
+    } else {
+      this.exprAllowed = true;
+    }
+  };
+
+  function beforeUpdateContext(prevType) {
+    if (this.type == tt.braceL) {
+      var curContext = this.curContext();
+      if (curContext == tc.j_oTag) this.context.push(tc.b_expr);
+      else if (curContext == tc.j_expr) this.context.push(tc.b_tmpl);
+      else return false;
+      this.exprAllowed = true;
+    } else if (this.type === tt.slash && prevType === tt.jsxTagStart) {
+      this.context.length -= 2; // do not consider JSX expr -> JSX open tag -> ... anymore
+      this.context.push(tc.j_cTag); // reconsider as closing tag context
+      this.exprAllowed = false;
+    } else {
+      return false;
+    }
+  }
+
+  function beforeTokenize(code) {
+    var context = this.curContext();
+
+    if (context === tc.j_expr) return this.jsx_readToken();
+
+    if (context === tc.j_oTag || context === tc.j_cTag) {
+      if (acorn.isIdentifierStart(code)) return this.jsx_readWord();
+
+      if (code == 62) {
+        ++this.pos;
+        return this.finishToken(tt.jsxTagEnd);
+      }
+
+      if ((code === 34 || code === 39) && context == tc.j_oTag)
+        return this.jsx_readString(code);
+    }
+
+    if (code === 60 && this.exprAllowed) {
+      ++this.pos;
+      return this.finishToken(tt.jsxTagStart);
+    }
+    return false;
+  }
+
+  var pp = acorn.Parser.prototype;
+
+  // Reads inline JSX contents token.
+
+  pp.jsx_readToken = function() {
+    var out = "", chunkStart = this.pos;
+    for (;;) {
+      if (this.pos >= this.input.length)
+        this.raise(this.start, "Unterminated JSX contents");
+      var ch = this.input.charCodeAt(this.pos);
+
+      switch (ch) {
+      case 60: // '<'
+      case 123: // '{'
+        if (this.pos === this.start) {
+          if (ch === 60 && this.exprAllowed) {
+            ++this.pos;
+            return this.finishToken(tt.jsxTagStart);
+          }
+          return this.getTokenFromCode(ch);
+        }
+        out += this.input.slice(chunkStart, this.pos);
+        return this.finishToken(tt.jsxText, out);
+
+      case 38: // '&'
+        out += this.input.slice(chunkStart, this.pos);
+        out += this.jsx_readEntity();
+        chunkStart = this.pos;
+        break;
+
+      default:
+        if (acorn.isNewLine(ch)) {
+          out += this.input.slice(chunkStart, this.pos);
+          ++this.pos;
+          if (ch === 13 && this.input.charCodeAt(this.pos) === 10) {
+            ++this.pos;
+            out += "\n";
+          } else {
+            out += String.fromCharCode(ch);
+          }
+          if (this.options.locations) {
+            ++this.curLine;
+            this.lineStart = this.pos;
+          }
+          chunkStart = this.pos;
+        } else {
+          ++this.pos;
+        }
+      }
+    }
+  };
+
+  pp.jsx_readString = function(quote) {
+    var out = "", chunkStart = ++this.pos;
+    for (;;) {
+      if (this.pos >= this.input.length)
+        this.raise(this.start, "Unterminated string constant");
+      var ch = this.input.charCodeAt(this.pos);
+      if (ch === quote) break;
+      if (ch === 38) { // '&'
+        out += this.input.slice(chunkStart, this.pos);
+        out += this.jsx_readEntity();
+        chunkStart = this.pos;
+      } else {
+        ++this.pos;
+      }
+    }
+    out += this.input.slice(chunkStart, this.pos++);
+    return this.finishToken(tt.string, out);
+  };
+
+  var XHTMLEntities = {
+    quot: '\u0022',
+    amp: '&',
+    apos: '\u0027',
+    lt: '<',
+    gt: '>',
+    nbsp: '\u00A0',
+    iexcl: '\u00A1',
+    cent: '\u00A2',
+    pound: '\u00A3',
+    curren: '\u00A4',
+    yen: '\u00A5',
+    brvbar: '\u00A6',
+    sect: '\u00A7',
+    uml: '\u00A8',
+    copy: '\u00A9',
+    ordf: '\u00AA',
+    laquo: '\u00AB',
+    not: '\u00AC',
+    shy: '\u00AD',
+    reg: '\u00AE',
+    macr: '\u00AF',
+    deg: '\u00B0',
+    plusmn: '\u00B1',
+    sup2: '\u00B2',
+    sup3: '\u00B3',
+    acute: '\u00B4',
+    micro: '\u00B5',
+    para: '\u00B6',
+    middot: '\u00B7',
+    cedil: '\u00B8',
+    sup1: '\u00B9',
+    ordm: '\u00BA',
+    raquo: '\u00BB',
+    frac14: '\u00BC',
+    frac12: '\u00BD',
+    frac34: '\u00BE',
+    iquest: '\u00BF',
+    Agrave: '\u00C0',
+    Aacute: '\u00C1',
+    Acirc: '\u00C2',
+    Atilde: '\u00C3',
+    Auml: '\u00C4',
+    Aring: '\u00C5',
+    AElig: '\u00C6',
+    Ccedil: '\u00C7',
+    Egrave: '\u00C8',
+    Eacute: '\u00C9',
+    Ecirc: '\u00CA',
+    Euml: '\u00CB',
+    Igrave: '\u00CC',
+    Iacute: '\u00CD',
+    Icirc: '\u00CE',
+    Iuml: '\u00CF',
+    ETH: '\u00D0',
+    Ntilde: '\u00D1',
+    Ograve: '\u00D2',
+    Oacute: '\u00D3',
+    Ocirc: '\u00D4',
+    Otilde: '\u00D5',
+    Ouml: '\u00D6',
+    times: '\u00D7',
+    Oslash: '\u00D8',
+    Ugrave: '\u00D9',
+    Uacute: '\u00DA',
+    Ucirc: '\u00DB',
+    Uuml: '\u00DC',
+    Yacute: '\u00DD',
+    THORN: '\u00DE',
+    szlig: '\u00DF',
+    agrave: '\u00E0',
+    aacute: '\u00E1',
+    acirc: '\u00E2',
+    atilde: '\u00E3',
+    auml: '\u00E4',
+    aring: '\u00E5',
+    aelig: '\u00E6',
+    ccedil: '\u00E7',
+    egrave: '\u00E8',
+    eacute: '\u00E9',
+    ecirc: '\u00EA',
+    euml: '\u00EB',
+    igrave: '\u00EC',
+    iacute: '\u00ED',
+    icirc: '\u00EE',
+    iuml: '\u00EF',
+    eth: '\u00F0',
+    ntilde: '\u00F1',
+    ograve: '\u00F2',
+    oacute: '\u00F3',
+    ocirc: '\u00F4',
+    otilde: '\u00F5',
+    ouml: '\u00F6',
+    divide: '\u00F7',
+    oslash: '\u00F8',
+    ugrave: '\u00F9',
+    uacute: '\u00FA',
+    ucirc: '\u00FB',
+    uuml: '\u00FC',
+    yacute: '\u00FD',
+    thorn: '\u00FE',
+    yuml: '\u00FF',
+    OElig: '\u0152',
+    oelig: '\u0153',
+    Scaron: '\u0160',
+    scaron: '\u0161',
+    Yuml: '\u0178',
+    fnof: '\u0192',
+    circ: '\u02C6',
+    tilde: '\u02DC',
+    Alpha: '\u0391',
+    Beta: '\u0392',
+    Gamma: '\u0393',
+    Delta: '\u0394',
+    Epsilon: '\u0395',
+    Zeta: '\u0396',
+    Eta: '\u0397',
+    Theta: '\u0398',
+    Iota: '\u0399',
+    Kappa: '\u039A',
+    Lambda: '\u039B',
+    Mu: '\u039C',
+    Nu: '\u039D',
+    Xi: '\u039E',
+    Omicron: '\u039F',
+    Pi: '\u03A0',
+    Rho: '\u03A1',
+    Sigma: '\u03A3',
+    Tau: '\u03A4',
+    Upsilon: '\u03A5',
+    Phi: '\u03A6',
+    Chi: '\u03A7',
+    Psi: '\u03A8',
+    Omega: '\u03A9',
+    alpha: '\u03B1',
+    beta: '\u03B2',
+    gamma: '\u03B3',
+    delta: '\u03B4',
+    epsilon: '\u03B5',
+    zeta: '\u03B6',
+    eta: '\u03B7',
+    theta: '\u03B8',
+    iota: '\u03B9',
+    kappa: '\u03BA',
+    lambda: '\u03BB',
+    mu: '\u03BC',
+    nu: '\u03BD',
+    xi: '\u03BE',
+    omicron: '\u03BF',
+    pi: '\u03C0',
+    rho: '\u03C1',
+    sigmaf: '\u03C2',
+    sigma: '\u03C3',
+    tau: '\u03C4',
+    upsilon: '\u03C5',
+    phi: '\u03C6',
+    chi: '\u03C7',
+    psi: '\u03C8',
+    omega: '\u03C9',
+    thetasym: '\u03D1',
+    upsih: '\u03D2',
+    piv: '\u03D6',
+    ensp: '\u2002',
+    emsp: '\u2003',
+    thinsp: '\u2009',
+    zwnj: '\u200C',
+    zwj: '\u200D',
+    lrm: '\u200E',
+    rlm: '\u200F',
+    ndash: '\u2013',
+    mdash: '\u2014',
+    lsquo: '\u2018',
+    rsquo: '\u2019',
+    sbquo: '\u201A',
+    ldquo: '\u201C',
+    rdquo: '\u201D',
+    bdquo: '\u201E',
+    dagger: '\u2020',
+    Dagger: '\u2021',
+    bull: '\u2022',
+    hellip: '\u2026',
+    permil: '\u2030',
+    prime: '\u2032',
+    Prime: '\u2033',
+    lsaquo: '\u2039',
+    rsaquo: '\u203A',
+    oline: '\u203E',
+    frasl: '\u2044',
+    euro: '\u20AC',
+    image: '\u2111',
+    weierp: '\u2118',
+    real: '\u211C',
+    trade: '\u2122',
+    alefsym: '\u2135',
+    larr: '\u2190',
+    uarr: '\u2191',
+    rarr: '\u2192',
+    darr: '\u2193',
+    harr: '\u2194',
+    crarr: '\u21B5',
+    lArr: '\u21D0',
+    uArr: '\u21D1',
+    rArr: '\u21D2',
+    dArr: '\u21D3',
+    hArr: '\u21D4',
+    forall: '\u2200',
+    part: '\u2202',
+    exist: '\u2203',
+    empty: '\u2205',
+    nabla: '\u2207',
+    isin: '\u2208',
+    notin: '\u2209',
+    ni: '\u220B',
+    prod: '\u220F',
+    sum: '\u2211',
+    minus: '\u2212',
+    lowast: '\u2217',
+    radic: '\u221A',
+    prop: '\u221D',
+    infin: '\u221E',
+    ang: '\u2220',
+    and: '\u2227',
+    or: '\u2228',
+    cap: '\u2229',
+    cup: '\u222A',
+    'int': '\u222B',
+    there4: '\u2234',
+    sim: '\u223C',
+    cong: '\u2245',
+    asymp: '\u2248',
+    ne: '\u2260',
+    equiv: '\u2261',
+    le: '\u2264',
+    ge: '\u2265',
+    sub: '\u2282',
+    sup: '\u2283',
+    nsub: '\u2284',
+    sube: '\u2286',
+    supe: '\u2287',
+    oplus: '\u2295',
+    otimes: '\u2297',
+    perp: '\u22A5',
+    sdot: '\u22C5',
+    lceil: '\u2308',
+    rceil: '\u2309',
+    lfloor: '\u230A',
+    rfloor: '\u230B',
+    lang: '\u2329',
+    rang: '\u232A',
+    loz: '\u25CA',
+    spades: '\u2660',
+    clubs: '\u2663',
+    hearts: '\u2665',
+    diams: '\u2666'
+  };
+
+  var hexNumber = /^[\da-fA-F]+$/;
+  var decimalNumber = /^\d+$/;
+
+  pp.jsx_readEntity = function() {
+    var str = "", count = 0, entity;
+    var ch = this.input[this.pos];
+    if (ch !== "&")
+      this.raise(this.pos, "Entity must start with an ampersand");
+    var startPos = ++this.pos;
+    while (this.pos < this.input.length && count++ < 10) {
+      ch = this.input[this.pos++];
+      if (ch === ";") {
+        if (str[0] === "#") {
+          if (str[1] === "x") {
+            str = str.substr(2);
+            if (hexNumber.test(str))
+              entity = String.fromCharCode(parseInt(str, 16));
+          } else {
+            str = str.substr(1);
+            if (decimalNumber.test(str))
+              entity = String.fromCharCode(parseInt(str, 10));
+          }
+        } else {
+          entity = XHTMLEntities[str];
+        }
+        break;
+      }
+      str += ch;
+    }
+    if (!entity) {
+      this.pos = startPos;
+      return "&";
+    }
+    return entity;
+  };
+
+
+  // Read a JSX identifier (valid tag or attribute name).
+  //
+  // Optimized version since JSX identifiers can't contain
+  // escape characters and so can be read as single slice.
+  // Also assumes that first character was already checked
+  // by isIdentifierStart in readToken.
+
+  pp.jsx_readWord = function() {
+    var ch, start = this.pos;
+    do {
+      ch = this.input.charCodeAt(++this.pos);
+    } while (acorn.isIdentifierChar(ch) || ch === 45); // '-'
+    return this.finishToken(tt.jsxName, this.input.slice(start, this.pos));
+  };
+
+  function beforeParseAtom() {
+    if (this.type === tt.jsxText)
+      return this.parseLiteral(this.value);
+    else if (this.type === tt.jsxTagStart)
+      return this.jsx_parseElement();
+    else
+      return false;
+  };
+
+  // Transforms JSX element name to string.
+
+  function getQualifiedJSXName(object) {
+    if (object.type === "JSXIdentifier")
+      return object.name;
+
+    if (object.type === "JSXNamespacedName")
+      return object.namespace.name + ':' + object.name.name;
+
+    if (object.type === "JSXMemberExpression")
+      return getQualifiedJSXName(object.object) + '.' +
+      getQualifiedJSXName(object.property);
+  }
+
+  // Parse next token as JSX identifier
+
+  pp.jsx_parseIdentifier = function() {
+    var node = this.startNode();
+    if (this.type === tt.jsxName)
+      node.name = this.value;
+    else if (this.type.keyword)
+      node.name = this.type.keyword;
+    else
+      this.unexpected();
+    this.next();
+    return this.finishNode(node, "JSXIdentifier");
+  };
+
+  // Parse namespaced identifier.
+
+  pp.jsx_parseNamespacedName = function() {
+    var start = this.currentPos();
+    var name = this.jsx_parseIdentifier();
+    if (!this.eat(tt.colon)) return name;
+    var node = this.startNodeAt(start);
+    node.namespace = name;
+    node.name = this.jsx_parseIdentifier();
+    return this.finishNode(node, "JSXNamespacedName");
+  };
+
+  // Parses element name in any form - namespaced, member
+  // or single identifier.
+
+  pp.jsx_parseElementName = function() {
+    var start = this.currentPos();
+    var node = this.jsx_parseNamespacedName();
+    while (this.eat(tt.dot)) {
+      var newNode = this.startNodeAt(start);
+      newNode.object = node;
+      newNode.property = this.jsx_parseIdentifier();
+      node = this.finishNode(newNode, "JSXMemberExpression");
+    }
+    return node;
+  };
+
+  // Parses any type of JSX attribute value.
+
+  pp.jsx_parseAttributeValue = function() {
+    switch (this.type) {
+    case tt.braceL:
+      var node = this.jsx_parseExpressionContainer();
+      if (node.expression.type === "JSXEmptyExpression")
+        this.raise(node.start, "JSX attributes must only be assigned a non-empty expression");
+      return node;
+
+    case tt.jsxTagStart:
+    case tt.string:
+      return this.parseExprAtom();
+
+    default:
+      this.raise(this.start, "JSX value should be either an expression or a quoted JSX text");
+    }
+  };
+
+  // JSXEmptyExpression is unique type since it doesn't actually parse anything,
+  // and so it should start at the end of last read token (left brace) and finish
+  // at the beginning of the next one (right brace).
+
+  pp.jsx_parseEmptyExpression = function() {
+    var tmp = this.start;
+    this.start = this.lastTokEnd;
+    this.lastTokEnd = tmp;
+
+    tmp = this.startLoc;
+    this.startLoc = this.lastTokEndLoc;
+    this.lastTokEndLoc = tmp;
+
+    return this.finishNode(this.startNode(), "JSXEmptyExpression");
+  };
+
+  // Parses JSX expression enclosed into curly brackets.
+
+
+  pp.jsx_parseExpressionContainer = function() {
+    var node = this.startNode();
+    this.next();
+    node.expression = this.type === tt.braceR
+      ? this.jsx_parseEmptyExpression()
+      : this.parseExpression();
+    this.expect(tt.braceR);
+    return this.finishNode(node, "JSXExpressionContainer");
+  };
+
+  // Parses following JSX attribute name-value pair.
+
+  pp.jsx_parseAttribute = function() {
+    var node = this.startNode();
+    if (this.eat(tt.braceL)) {
+      this.expect(tt.ellipsis);
+      node.argument = this.parseMaybeAssign();
+      this.expect(tt.braceR);
+      return this.finishNode(node, "JSXSpreadAttribute");
+    }
+    node.name = this.jsx_parseNamespacedName();
+    node.value = this.eat(tt.eq) ? this.jsx_parseAttributeValue() : null;
+    return this.finishNode(node, "JSXAttribute");
+  };
+
+  // Parses JSX opening tag starting after '<'.
+
+  pp.jsx_parseOpeningElementAt = function(start) {
+    var node = this.startNodeAt(start);
+    node.attributes = [];
+    node.name = this.jsx_parseElementName();
+    while (this.type !== tt.slash && this.type !== tt.jsxTagEnd)
+      node.attributes.push(this.jsx_parseAttribute());
+    node.selfClosing = this.eat(tt.slash);
+    this.expect(tt.jsxTagEnd);
+    return this.finishNode(node, "JSXOpeningElement");
+  };
+
+  // Parses JSX closing tag starting after '</'.
+
+  pp.jsx_parseClosingElementAt = function(start) {
+    var node = this.startNodeAt(start);
+    node.name = this.jsx_parseElementName();
+    this.expect(tt.jsxTagEnd);
+    return this.finishNode(node, "JSXClosingElement");
+  };
+
+  // Parses entire JSX element, including it's opening tag
+  // (starting after '<'), attributes, contents and closing tag.
+
+  pp.jsx_parseElementAt = function(start) {
+    var node = this.startNodeAt(start);
+    var children = [];
+    var openingElement = this.jsx_parseOpeningElementAt(start);
+    var closingElement = null;
+
+    if (!openingElement.selfClosing) {
+      contents: for (;;) {
+        switch (this.type) {
+        case tt.jsxTagStart:
+          start = this.currentPos();
+          this.next();
+          if (this.eat(tt.slash)) {
+            closingElement = this.jsx_parseClosingElementAt(start);
+            break contents;
+          }
+          children.push(this.jsx_parseElementAt(start));
+          break;
+
+        case tt.jsxText:
+          children.push(this.parseExprAtom());
+          break;
+
+        case tt.braceL:
+          children.push(this.jsx_parseExpressionContainer());
+          break;
+
+        default:
+          this.unexpected();
+        }
+      }
+      if (getQualifiedJSXName(closingElement.name) !== getQualifiedJSXName(openingElement.name))
+        this.raise(
+          closingElement.start,
+          "Expected corresponding JSX closing tag for <" + getQualifiedJSXName(openingElement.name) + ">");
+    }
+
+    node.openingElement = openingElement;
+    node.closingElement = closingElement;
+    node.children = children;
+    return this.finishNode(node, "JSXElement");
+  };
+
+  // Parses entire JSX element from current position.
+
+  pp.jsx_parseElement = function() {
+    var start = this.currentPos();
+    this.next();
+    return this.jsx_parseElementAt(start);
+  };
+
+  acorn.plugins.jsx = {
+    parseExprAtom: beforeParseAtom,
+    tokenize: beforeTokenize,
+    updateContext: beforeUpdateContext
+  };
+});

--- a/test/driver.js
+++ b/test/driver.js
@@ -33,8 +33,7 @@
           } else {
             callback("fail", test.code, "Expected error message: " + test.error + "\nBut parsing succeeded.");
           }
-        }
-        else if (test.assert) {
+        } else if (test.assert) {
           var error = test.assert(ast);
           if (error) callback("fail", test.code,
                                  "\n  Assertion failed:\n " + error);

--- a/test/index.html
+++ b/test/index.html
@@ -4,9 +4,11 @@
   <title>Acorn test suite</title>
   <script src="../acorn.js"></script>
   <script src="../acorn_loose.js"></script>
+  <script src="../plugin/jsx.js"></script>
   <script src="driver.js"></script>
   <script src="tests.js" charset="utf-8"></script>
   <script src="tests-harmony.js" charset="utf-8"></script>
+  <script src="tests-jsx.js" charset="utf-8"></script>
 </head>
 <body>
   <ul id="log"></ul>

--- a/test/run.js
+++ b/test/run.js
@@ -5,6 +5,8 @@
     driver = require("./driver.js");
     require("./tests.js");
     require("./tests-harmony.js");
+    require("./tests-jsx.js");
+    require("../plugin/jsx.js");
   } else {
     driver = window;
   }

--- a/test/tests-jsx.js
+++ b/test/tests-jsx.js
@@ -1,0 +1,3648 @@
+// React JSX tests
+
+var fbTestFixture = {
+  // Taken and adapted from esprima-fb/fbtest.js.
+  'JSX': {
+    '<a />': {
+      type: "ExpressionStatement",
+      expression: {
+        type: "JSXElement",
+        openingElement: {
+          type: "JSXOpeningElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "a",
+            range: [1, 2],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 2 }
+            }
+          },
+          selfClosing: true,
+          attributes: [],
+          range: [0, 5],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 5 }
+          }
+        },
+        closingElement: null,
+        children: [],
+        range: [0, 5],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 5 }
+        }
+      },
+      range: [0, 5],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 5 }
+      }
+    },
+
+    '<n:a n:v />': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXNamespacedName',
+            namespace: {
+              type: 'JSXIdentifier',
+              name: 'n',
+              range: [1, 2],
+              loc: {
+                start: { line: 1, column: 1 },
+                end: { line: 1, column: 2 }
+              }
+            },
+            name: {
+              type: 'JSXIdentifier',
+              name: 'a',
+              range: [3, 4],
+              loc: {
+                start: { line: 1, column: 3 },
+                end: { line: 1, column: 4 }
+              }
+            },
+            range: [1, 4],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 4 }
+            }
+          },
+          selfClosing: true,
+          attributes: [{
+            type: 'JSXAttribute',
+            name: {
+              type: 'JSXNamespacedName',
+              namespace: {
+                type: 'JSXIdentifier',
+                name: 'n',
+                range: [5, 6],
+                loc: {
+                  start: { line: 1, column: 5 },
+                  end: { line: 1, column: 6 }
+                }
+              },
+              name: {
+                type: 'JSXIdentifier',
+                name: 'v',
+                range: [7, 8],
+                loc: {
+                  start: { line: 1, column: 7 },
+                  end: { line: 1, column: 8 }
+                }
+              },
+              range: [5, 8],
+              loc: {
+                start: { line: 1, column: 5 },
+                end: { line: 1, column: 8 }
+              }
+            },
+            value: null,
+            range: [5, 8],
+            loc: {
+              start: { line: 1, column: 5 },
+              end: { line: 1, column: 8 }
+            }
+          }],
+          range: [0, 11],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 11 }
+          }
+        },
+        closingElement: null,
+        children: [],
+        range: [0, 11],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 11 }
+        }
+      },
+      range: [0, 11],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 11 }
+      }
+    },
+
+    '<a n:foo="bar"> {value} <b><c /></b></a>': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'a',
+            range: [1, 2],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 2 }
+            }
+          },
+          selfClosing: false,
+          attributes: [{
+            type: 'JSXAttribute',
+            name: {
+              type: 'JSXNamespacedName',
+              namespace: {
+                type: 'JSXIdentifier',
+                name: 'n',
+                range: [3, 4],
+                loc: {
+                  start: { line: 1, column: 3 },
+                  end: { line: 1, column: 4 }
+                }
+              },
+              name: {
+                type: 'JSXIdentifier',
+                name: 'foo',
+                range: [5, 8],
+                loc: {
+                  start: { line: 1, column: 5 },
+                  end: { line: 1, column: 8 }
+                }
+              },
+              range: [3, 8],
+              loc: {
+                start: { line: 1, column: 3 },
+                end: { line: 1, column: 8 }
+              }
+            },
+            value: {
+              type: 'Literal',
+              value: 'bar',
+              raw: '"bar"',
+              range: [9, 14],
+              loc: {
+                start: { line: 1, column: 9 },
+                end: { line: 1, column: 14 }
+              }
+            },
+            range: [3, 14],
+            loc: {
+              start: { line: 1, column: 3 },
+              end: { line: 1, column: 14 }
+            }
+          }],
+          range: [0, 15],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 15 }
+          }
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'a',
+            range: [38, 39],
+            loc: {
+              start: { line: 1, column: 38 },
+              end: { line: 1, column: 39 }
+            }
+          },
+          range: [36, 40],
+          loc: {
+            start: { line: 1, column: 36 },
+            end: { line: 1, column: 40 }
+          }
+        },
+        children: [{
+          type: 'Literal',
+          value: ' ',
+          raw: ' ',
+          range: [15, 16],
+          loc: {
+            start: { line: 1, column: 15 },
+            end: { line: 1, column: 16 }
+          }
+        }, {
+          type: 'JSXExpressionContainer',
+          expression: {
+            type: 'Identifier',
+            name: 'value',
+            range: [17, 22],
+            loc: {
+              start: { line: 1, column: 17 },
+              end: { line: 1, column: 22 }
+            }
+          },
+          range: [16, 23],
+          loc: {
+            start: { line: 1, column: 16 },
+            end: { line: 1, column: 23 }
+          }
+        }, {
+          type: 'Literal',
+          value: ' ',
+          raw: ' ',
+          range: [23, 24],
+          loc: {
+            start: { line: 1, column: 23 },
+            end: { line: 1, column: 24 }
+          }
+        }, {
+          type: 'JSXElement',
+          openingElement: {
+            type: 'JSXOpeningElement',
+            name: {
+              type: 'JSXIdentifier',
+              name: 'b',
+              range: [25, 26],
+              loc: {
+                start: { line: 1, column: 25 },
+                end: { line: 1, column: 26 }
+              }
+            },
+            selfClosing: false,
+            attributes: [],
+            range: [24, 27],
+            loc: {
+              start: { line: 1, column: 24 },
+              end: { line: 1, column: 27 }
+            }
+          },
+          closingElement: {
+            type: 'JSXClosingElement',
+            name: {
+              type: 'JSXIdentifier',
+              name: 'b',
+              range: [34, 35],
+              loc: {
+                start: { line: 1, column: 34 },
+                end: { line: 1, column: 35 }
+              }
+            },
+            range: [32, 36],
+            loc: {
+              start: { line: 1, column: 32 },
+              end: { line: 1, column: 36 }
+            }
+          },
+          children: [{
+            type: 'JSXElement',
+            openingElement: {
+              type: 'JSXOpeningElement',
+              name: {
+                type: 'JSXIdentifier',
+                name: 'c',
+                range: [28, 29],
+                loc: {
+                  start: { line: 1, column: 28 },
+                  end: { line: 1, column: 29 }
+                }
+              },
+              selfClosing: true,
+              attributes: [],
+              range: [27, 32],
+              loc: {
+                start: { line: 1, column: 27 },
+                end: { line: 1, column: 32 }
+              }
+            },
+            closingElement: null,
+            children: [],
+            range: [27, 32],
+            loc: {
+              start: { line: 1, column: 27 },
+              end: { line: 1, column: 32 }
+            }
+          }],
+          range: [24, 36],
+          loc: {
+            start: { line: 1, column: 24 },
+            end: { line: 1, column: 36 }
+          }
+        }],
+        range: [0, 40],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 40 }
+        }
+      },
+      range: [0, 40],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 40 }
+      }
+    },
+
+    '<a b={" "} c=" " d="&amp;" e="&ampr;" />': {
+      type: "ExpressionStatement",
+      expression: {
+        type: "JSXElement",
+        openingElement: {
+          type: "JSXOpeningElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "a",
+            range: [1, 2]
+          },
+          selfClosing: true,
+          attributes: [
+            {
+              type: "JSXAttribute",
+              name: {
+                type: "JSXIdentifier",
+                name: "b",
+                range: [3, 4]
+              },
+              value: {
+                type: "JSXExpressionContainer",
+                expression: {
+                  type: "Literal",
+                  value: " ",
+                  raw: "\" \"",
+                  range: [6, 9]
+                },
+                range: [5, 10]
+              },
+              range: [3, 10]
+            },
+            {
+              type: "JSXAttribute",
+              name: {
+                type: "JSXIdentifier",
+                name: "c",
+                range: [11, 12]
+              },
+              value: {
+                type: "Literal",
+                value: " ",
+                raw: "\" \"",
+                range: [13, 16]
+              },
+              range: [11, 16]
+            },
+            {
+              type: "JSXAttribute",
+              name: {
+                type: "JSXIdentifier",
+                name: "d",
+                range: [17, 18]
+              },
+              value: {
+                type: "Literal",
+                value: "&",
+                raw: "\"&amp;\"",
+                range: [19, 26]
+              },
+              range: [17, 26]
+            },
+            {
+              type: "JSXAttribute",
+              name: {
+                type: "JSXIdentifier",
+                name: "e",
+                range: [27, 28]
+              },
+              value: {
+                type: "Literal",
+                value: "&ampr;",
+                raw: "\"&ampr;\"",
+                range: [29, 37]
+              },
+              range: [27, 37]
+            }
+          ],
+          range: [0, 40]
+        },
+        closingElement: null,
+        children: [],
+        range: [0, 40]
+      },
+      range: [0, 40]
+    },
+
+    '<a\n/>': {
+      type: "ExpressionStatement",
+      expression: {
+        type: "JSXElement",
+        openingElement: {
+          type: "JSXOpeningElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "a",
+            range: [
+              1,
+              2
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 2
+              }
+            }
+          },
+          selfClosing: true,
+          attributes: [],
+          range: [
+            0,
+            5
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 2,
+              column: 2
+            }
+          }
+        },
+        closingElement: null,
+        children: [],
+        range: [
+          0,
+          5
+        ],
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 2,
+            column: 2
+          }
+        }
+      },
+      range: [
+        0,
+        5
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 2,
+          column: 2
+        }
+      }
+    },
+
+    '<日本語></日本語>': {
+      type: "ExpressionStatement",
+      expression: {
+        type: "JSXElement",
+        openingElement: {
+          type: "JSXOpeningElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "日本語",
+            range: [
+              1,
+              4
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 4
+              }
+            }
+          },
+          selfClosing: false,
+          attributes: [],
+          range: [
+            0,
+            5
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 1,
+              column: 5
+            }
+          }
+        },
+        closingElement: {
+          type: "JSXClosingElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "日本語",
+            range: [
+              7,
+              10
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 7
+              },
+              end: {
+                line: 1,
+                column: 10
+              }
+            }
+          },
+          range: [
+            5,
+            11
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 5
+            },
+            end: {
+              line: 1,
+              column: 11
+            }
+          }
+        },
+        children: [],
+        range: [
+          0,
+          11
+        ],
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 1,
+            column: 11
+          }
+        }
+      },
+      range: [
+        0,
+        11
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 11
+        }
+      }
+    },
+
+    '<AbC-def\n  test="&#x0026;&#38;">\nbar\nbaz\n</AbC-def>': {
+      type: "ExpressionStatement",
+      expression: {
+        type: "JSXElement",
+        openingElement: {
+          type: "JSXOpeningElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "AbC-def",
+            range: [
+              1,
+              8
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 8
+              }
+            }
+          },
+          selfClosing: false,
+          attributes: [
+            {
+              type: "JSXAttribute",
+              name: {
+                type: "JSXIdentifier",
+                name: "test",
+                range: [
+                  11,
+                  15
+                ],
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 2
+                  },
+                  end: {
+                    line: 2,
+                    column: 6
+                  }
+                }
+              },
+              value: {
+                type: "Literal",
+                value: "&&",
+                raw: "\"&#x0026;&#38;\"",
+                range: [
+                  16,
+                  31
+                ],
+                loc: {
+                  start: {
+                    line: 2,
+                    column: 7
+                  },
+                  end: {
+                    line: 2,
+                    column: 22
+                  }
+                }
+              },
+              range: [
+                11,
+                31
+              ],
+              loc: {
+                start: {
+                  line: 2,
+                  column: 2
+                },
+                end: {
+                  line: 2,
+                  column: 22
+                }
+              }
+            }
+          ],
+          range: [
+            0,
+            32
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 2,
+              column: 23
+            }
+          }
+        },
+        closingElement: {
+          type: "JSXClosingElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "AbC-def",
+            range: [
+              43,
+              50
+            ],
+            loc: {
+              start: {
+                line: 5,
+                column: 2
+              },
+              end: {
+                line: 5,
+                column: 9
+              }
+            }
+          },
+          range: [
+            41,
+            51
+          ],
+          loc: {
+            start: {
+              line: 5,
+              column: 0
+            },
+            end: {
+              line: 5,
+              column: 10
+            }
+          }
+        },
+        children: [
+          {
+            type: "Literal",
+            value: "\nbar\nbaz\n",
+            raw: "\nbar\nbaz\n",
+            range: [
+              32,
+              41
+            ],
+            loc: {
+              start: {
+                line: 2,
+                column: 23
+              },
+              end: {
+                line: 5,
+                column: 0
+              }
+            }
+          }
+        ],
+        range: [
+          0,
+          51
+        ],
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 5,
+            column: 10
+          }
+        }
+      },
+      range: [
+        0,
+        51
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 5,
+          column: 10
+        }
+      }
+    },
+
+    '<a b={x ? <c /> : <d />} />': {
+      type: "ExpressionStatement",
+      expression: {
+        type: "JSXElement",
+        openingElement: {
+          type: "JSXOpeningElement",
+          name: {
+            type: "JSXIdentifier",
+            name: "a",
+            range: [
+              1,
+              2
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 2
+              }
+            }
+          },
+          selfClosing: true,
+          attributes: [
+            {
+              type: "JSXAttribute",
+              name: {
+                type: "JSXIdentifier",
+                name: "b",
+                range: [
+                  3,
+                  4
+                ],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 3
+                  },
+                  end: {
+                    line: 1,
+                    column: 4
+                  }
+                }
+              },
+              value: {
+                type: "JSXExpressionContainer",
+                expression: {
+                  type: "ConditionalExpression",
+                  test: {
+                    type: "Identifier",
+                    name: "x",
+                    range: [
+                      6,
+                      7
+                    ],
+                    loc: {
+                      start: {
+                        line: 1,
+                        column: 6
+                      },
+                      end: {
+                        line: 1,
+                        column: 7
+                      }
+                    }
+                  },
+                  consequent: {
+                    type: "JSXElement",
+                    openingElement: {
+                      type: "JSXOpeningElement",
+                      name: {
+                        type: "JSXIdentifier",
+                        name: "c",
+                        range: [
+                          11,
+                          12
+                        ],
+                        loc: {
+                          start: {
+                            line: 1,
+                            column: 11
+                          },
+                          end: {
+                            line: 1,
+                            column: 12
+                          }
+                        }
+                      },
+                      selfClosing: true,
+                      attributes: [],
+                      range: [
+                        10,
+                        15
+                      ],
+                      loc: {
+                        start: {
+                          line: 1,
+                          column: 10
+                        },
+                        end: {
+                          line: 1,
+                          column: 15
+                        }
+                      }
+                    },
+                    closingElement: null,
+                    children: [],
+                    range: [
+                      10,
+                      15
+                    ],
+                    loc: {
+                      start: {
+                        line: 1,
+                        column: 10
+                      },
+                      end: {
+                        line: 1,
+                        column: 15
+                      }
+                    }
+                  },
+                  alternate: {
+                    type: "JSXElement",
+                    openingElement: {
+                      type: "JSXOpeningElement",
+                      name: {
+                        type: "JSXIdentifier",
+                        name: "d",
+                        range: [
+                          19,
+                          20
+                        ],
+                        loc: {
+                          start: {
+                            line: 1,
+                            column: 19
+                          },
+                          end: {
+                            line: 1,
+                            column: 20
+                          }
+                        }
+                      },
+                      selfClosing: true,
+                      attributes: [],
+                      range: [
+                        18,
+                        23
+                      ],
+                      loc: {
+                        start: {
+                          line: 1,
+                          column: 18
+                        },
+                        end: {
+                          line: 1,
+                          column: 23
+                        }
+                      }
+                    },
+                    closingElement: null,
+                    children: [],
+                    range: [
+                      18,
+                      23
+                    ],
+                    loc: {
+                      start: {
+                        line: 1,
+                        column: 18
+                      },
+                      end: {
+                        line: 1,
+                        column: 23
+                      }
+                    }
+                  },
+                  range: [
+                    6,
+                    23
+                  ],
+                  loc: {
+                    start: {
+                      line: 1,
+                      column: 6
+                    },
+                    end: {
+                      line: 1,
+                      column: 23
+                    }
+                  }
+                },
+                range: [
+                  5,
+                  24
+                ],
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 5
+                  },
+                  end: {
+                    line: 1,
+                    column: 24
+                  }
+                }
+              },
+              range: [
+                3,
+                24
+              ],
+              loc: {
+                start: {
+                  line: 1,
+                  column: 3
+                },
+                end: {
+                  line: 1,
+                  column: 24
+                }
+              }
+            }
+          ],
+          range: [
+            0,
+            27
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 1,
+              column: 27
+            }
+          }
+        },
+        closingElement: null,
+        children: [],
+        range: [
+          0,
+          27
+        ],
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 1,
+            column: 27
+          }
+        }
+      },
+      range: [
+        0,
+        27
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 27
+        }
+      }
+    },
+
+    '<a>{}</a>': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'a',
+            range: [1, 2],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 2 }
+            }
+          },
+          selfClosing: false,
+          attributes: [],
+          range: [0, 3],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 3 }
+          }
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'a',
+            range: [7, 8],
+            loc: {
+              start: { line: 1, column: 7 },
+              end: { line: 1, column: 8 }
+            }
+          },
+          range: [5, 9],
+          loc: {
+            start: { line: 1, column: 5 },
+            end: { line: 1, column: 9 }
+          }
+        },
+        children: [{
+          type: 'JSXExpressionContainer',
+          expression: {
+            type: 'JSXEmptyExpression',
+            range: [4, 4],
+            loc: {
+              start: { line: 1, column: 4 },
+              end: { line: 1, column: 4 }
+            }
+          },
+          range: [3, 5],
+          loc: {
+            start: { line: 1, column: 3 },
+            end: { line: 1, column: 5 }
+          }
+        }],
+        range: [0, 9],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 9 }
+        }
+      },
+      range: [0, 9],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 9 }
+      }
+    },
+
+    '<a>{/* this is a comment */}</a>': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'a',
+            range: [1, 2],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 2 }
+            }
+          },
+          selfClosing: false,
+          attributes: [],
+          range: [0, 3],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 3 }
+          }
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'a',
+            range: [30, 31],
+            loc: {
+              start: { line: 1, column: 30 },
+              end: { line: 1, column: 31 }
+            }
+          },
+          range: [28, 32],
+          loc: {
+            start: { line: 1, column: 28 },
+            end: { line: 1, column: 32 }
+          }
+        },
+        children: [{
+          type: 'JSXExpressionContainer',
+          expression: {
+            type: 'JSXEmptyExpression',
+            range: [4, 27],
+            loc: {
+              start: { line: 1, column: 4 },
+              end: { line: 1, column: 27 }
+            }
+          },
+          range: [3, 28],
+          loc: {
+            start: { line: 1, column: 3 },
+            end: { line: 1, column: 28 }
+          }
+        }],
+        range: [0, 32],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 32 }
+        }
+      },
+      range: [0, 32],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 32 }
+      }
+    },
+
+    '<div>@test content</div>': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'div',
+            range: [1, 4],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 4 }
+            }
+          },
+          selfClosing: false,
+          attributes: [],
+          range: [0, 5],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 5 }
+          }
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'div',
+            range: [20, 23],
+            loc: {
+              start: { line: 1, column: 20 },
+              end: { line: 1, column: 23 }
+            }
+          },
+          range: [18, 24],
+          loc: {
+            start: { line: 1, column: 18 },
+            end: { line: 1, column: 24 }
+          }
+        },
+        children: [{
+          type: 'Literal',
+          value: '@test content',
+          raw: '@test content',
+          range: [5, 18],
+          loc: {
+            start: { line: 1, column: 5 },
+            end: { line: 1, column: 18 }
+          }
+        }],
+        range: [0, 24],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 24 }
+        }
+      },
+      range: [0, 24],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 24 }
+      }
+    },
+
+    '<div><br />7x invalid-js-identifier</div>': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'div',
+            range: [
+              1,
+              4
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 1
+              },
+              end: {
+                line: 1,
+                column: 4
+              }
+            }
+          },
+          selfClosing: false,
+          attributes: [],
+          range: [
+            0,
+            5
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 0
+            },
+            end: {
+              line: 1,
+              column: 5
+            }
+          }
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: {
+            type: 'JSXIdentifier',
+            name: 'div',
+            range: [
+              37,
+              40
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 37
+              },
+              end: {
+                line: 1,
+                column: 40
+              }
+            }
+          },
+          range: [
+            35,
+            41
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 35
+            },
+            end: {
+              line: 1,
+              column: 41
+            }
+          }
+        },
+        children: [{
+          type: 'JSXElement',
+          openingElement: {
+            type: 'JSXOpeningElement',
+            name: {
+              type: 'JSXIdentifier',
+              name: 'br',
+              range: [
+                6,
+                8
+              ],
+              loc: {
+                start: {
+                  line: 1,
+                  column: 6
+                },
+                end: {
+                  line: 1,
+                  column: 8
+                }
+              }
+            },
+            selfClosing: true,
+            attributes: [],
+            range: [
+              5,
+              11
+            ],
+            loc: {
+              start: {
+                line: 1,
+                column: 5
+              },
+              end: {
+                line: 1,
+                column: 11
+              }
+            }
+          },
+          closingElement: null,
+          children: [],
+          range: [
+            5,
+            11
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 5
+            },
+            end: {
+              line: 1,
+              column: 11
+            }
+          }
+        }, {
+          type: 'Literal',
+          value: '7x invalid-js-identifier',
+          raw: '7x invalid-js-identifier',
+          range: [
+            11,
+            35
+          ],
+          loc: {
+            start: {
+              line: 1,
+              column: 11
+            },
+            end: {
+              line: 1,
+              column: 35
+            }
+          }
+        }],
+        range: [
+          0,
+          41
+        ],
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 1,
+            column: 41
+          }
+        }
+      },
+      range: [
+        0,
+        41
+      ],
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 41
+        }
+      }
+    },
+
+    '<LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />': {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "JSXElement",
+        "openingElement": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXIdentifier",
+            "name": "LeftRight",
+            "range": [
+              1,
+              10
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 10
+              }
+            }
+          },
+          "selfClosing": true,
+          "attributes": [
+            {
+              "type": "JSXAttribute",
+              "name": {
+                "type": "JSXIdentifier",
+                "name": "left",
+                "range": [
+                  11,
+                  15
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 15
+                  }
+                }
+              },
+              "value": {
+                "type": "JSXElement",
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "name": "a",
+                    "range": [
+                      17,
+                      18
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 18
+                      }
+                    }
+                  },
+                  "selfClosing": true,
+                  "attributes": [],
+                  "range": [
+                    16,
+                    21
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 21
+                    }
+                  }
+                },
+                closingElement: null,
+                "children": [],
+                "range": [
+                  16,
+                  21
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 21
+                  }
+                }
+              },
+              "range": [
+                11,
+                21
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 11
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                }
+              }
+            },
+            {
+              "type": "JSXAttribute",
+              "name": {
+                "type": "JSXIdentifier",
+                "name": "right",
+                "range": [
+                  22,
+                  27
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 22
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 27
+                  }
+                }
+              },
+              "value": {
+                "type": "JSXElement",
+                "openingElement": {
+                  "type": "JSXOpeningElement",
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "name": "b",
+                    "range": [
+                      29,
+                      30
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 30
+                      }
+                    }
+                  },
+                  "selfClosing": false,
+                  "attributes": [],
+                  "range": [
+                    28,
+                    31
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 28
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 31
+                    }
+                  }
+                },
+                "closingElement": {
+                  "type": "JSXClosingElement",
+                  "name": {
+                    "type": "JSXIdentifier",
+                    "name": "b",
+                    "range": [
+                      52,
+                      53
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 52
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 53
+                      }
+                    }
+                  },
+                  "range": [
+                    50,
+                    54
+                  ],
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 50
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 54
+                    }
+                  }
+                },
+                "children": [
+                  {
+                    "type": "Literal",
+                    "value": "monkeys /> gorillas",
+                    "raw": "monkeys /> gorillas",
+                    "range": [
+                      31,
+                      50
+                    ],
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 31
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 50
+                      }
+                    }
+                  }
+                ],
+                "range": [
+                  28,
+                  54
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 28
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 54
+                  }
+                }
+              },
+              "range": [
+                22,
+                54
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 22
+                },
+                "end": {
+                  "line": 1,
+                  "column": 54
+                }
+              }
+            }
+          ],
+          "range": [
+            0,
+            57
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 57
+            }
+          }
+        },
+        closingElement: null,
+        "children": [],
+        "range": [
+          0,
+          57
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 57
+          }
+        }
+      },
+      "range": [
+        0,
+        57
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 57
+        }
+      }
+    },
+
+    '<a.b></a.b>': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXMemberExpression',
+            object: {
+              type: 'JSXIdentifier',
+              name: 'a',
+              range: [1, 2],
+              loc: {
+                start: { line: 1, column: 1 },
+                end: { line: 1, column: 2 }
+              }
+            },
+            property: {
+              type: 'JSXIdentifier',
+              name: 'b',
+              range: [3, 4],
+              loc: {
+                start: { line: 1, column: 3 },
+                end: { line: 1, column: 4 }
+              }
+            },
+            range: [1, 4],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 4 }
+            }
+          },
+          selfClosing: false,
+          attributes: [],
+          range: [0, 5],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 5 }
+          }
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: {
+            type: 'JSXMemberExpression',
+            object: {
+              type: 'JSXIdentifier',
+              name: 'a',
+              range: [7, 8],
+              loc: {
+                start: { line: 1, column: 7 },
+                end: { line: 1, column: 8 }
+              }
+            },
+            property: {
+              type: 'JSXIdentifier',
+              name: 'b',
+              range: [9, 10],
+              loc: {
+                start: { line: 1, column: 9 },
+                end: { line: 1, column: 10 }
+              }
+            },
+            range: [7, 10],
+            loc: {
+              start: { line: 1, column: 7 },
+              end: { line: 1, column: 10 }
+            }
+          },
+          range: [5, 11],
+          loc: {
+            start: { line: 1, column: 5 },
+            end: { line: 1, column: 11 }
+          }
+        },
+        children: [],
+        range: [0, 11],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 11 }
+        }
+      },
+      range: [0, 11],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 11 }
+      }
+    },
+
+    '<a.b.c></a.b.c>': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'JSXElement',
+        openingElement: {
+          type: 'JSXOpeningElement',
+          name: {
+            type: 'JSXMemberExpression',
+            object: {
+              type: 'JSXMemberExpression',
+              object: {
+                type: 'JSXIdentifier',
+                name: 'a',
+                range: [1, 2],
+                loc: {
+                  start: { line: 1, column: 1 },
+                  end: { line: 1, column: 2 }
+                }
+              },
+              property: {
+                type: 'JSXIdentifier',
+                name: 'b',
+                range: [3, 4],
+                loc: {
+                  start: { line: 1, column: 3 },
+                  end: { line: 1, column: 4 }
+                }
+              },
+              range: [1, 4],
+              loc: {
+                start: { line: 1, column: 1 },
+                end: { line: 1, column: 4 }
+              }
+            },
+            property: {
+              type: 'JSXIdentifier',
+              name: 'c',
+              range: [5, 6],
+              loc: {
+                start: { line: 1, column: 5 },
+                end: { line: 1, column: 6 }
+              }
+            },
+            range: [1, 6],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 6 }
+            }
+          },
+          selfClosing: false,
+          attributes: [],
+          range: [0, 7],
+          loc: {
+            start: { line: 1, column: 0 },
+            end: { line: 1, column: 7 }
+          }
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          name: {
+            type: 'JSXMemberExpression',
+            object: {
+              type: 'JSXMemberExpression',
+              object: {
+                type: 'JSXIdentifier',
+                name: 'a',
+                range: [9, 10],
+                loc: {
+                  start: { line: 1, column: 9 },
+                  end: { line: 1, column: 10 }
+                }
+              },
+              property: {
+                type: 'JSXIdentifier',
+                name: 'b',
+                range: [11, 12],
+                loc: {
+                  start: { line: 1, column: 11 },
+                  end: { line: 1, column: 12 }
+                }
+              },
+              range: [9, 12],
+              loc: {
+                start: { line: 1, column: 9 },
+                end: { line: 1, column: 12 }
+              }
+            },
+            property: {
+              type: 'JSXIdentifier',
+              name: 'c',
+              range: [13, 14],
+              loc: {
+                start: { line: 1, column: 13 },
+                end: { line: 1, column: 14 }
+              }
+            },
+            range: [9, 14],
+            loc: {
+              start: { line: 1, column: 9 },
+              end: { line: 1, column: 14 }
+            }
+          },
+          range: [7, 15],
+          loc: {
+            start: { line: 1, column: 7 },
+            end: { line: 1, column: 15 }
+          }
+        },
+        children: [],
+        range: [0, 15],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 15 }
+        }
+      },
+      range: [0, 15],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 15 }
+      }
+    },
+
+    // In order to more useful parse errors, we disallow following an
+    // JSXElement by a less-than symbol. In the rare case that the binary
+    // operator was intended, the tag can be wrapped in parentheses:
+    '(<div />) < x;': {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'BinaryExpression',
+        operator: '<',
+        left: {
+          type: 'JSXElement',
+          openingElement: {
+            type: 'JSXOpeningElement',
+            name: {
+              type: 'JSXIdentifier',
+              name: 'div',
+              range: [2, 5],
+              loc: {
+                start: { line: 1, column: 2 },
+                end: { line: 1, column: 5 }
+              }
+            },
+            selfClosing: true,
+            attributes: [],
+            range: [1, 8],
+            loc: {
+              start: { line: 1, column: 1 },
+              end: { line: 1, column: 8 }
+            }
+          },
+          closingElement: null,
+          children: [],
+          range: [1, 8],
+          loc: {
+            start: { line: 1, column: 1 },
+            end: { line: 1, column: 8 }
+          }
+        },
+        right: {
+          type: 'Identifier',
+          name: 'x',
+          range: [12, 13],
+          loc: {
+            start: { line: 1, column: 12 },
+            end: { line: 1, column: 13 }
+          }
+        },
+        range: [0, 13],
+        loc: {
+          start: { line: 1, column: 0 },
+          end: { line: 1, column: 13 }
+        }
+      },
+      range: [0, 14],
+      loc: {
+        start: { line: 1, column: 0 },
+        end: { line: 1, column: 14 }
+      }
+    },
+
+    '<div {...props} />': {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "JSXElement",
+        "openingElement": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXIdentifier",
+            "name": "div",
+            "range": [
+              1,
+              4
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          },
+          "selfClosing": true,
+          "attributes": [
+            {
+              "type": "JSXSpreadAttribute",
+              "argument": {
+                "type": "Identifier",
+                "name": "props",
+                "range": [
+                  9,
+                  14
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 14
+                  }
+                }
+              },
+              "range": [
+                5,
+                15
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 5
+                },
+                "end": {
+                  "line": 1,
+                  "column": 15
+                }
+              }
+            }
+          ],
+          "range": [
+            0,
+            18
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 18
+            }
+          }
+        },
+        closingElement: null,
+        "children": [],
+        "range": [
+          0,
+          18
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        }
+      },
+      "range": [
+        0,
+        18
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 18
+        }
+      }
+    },
+
+    '<div {...props} post="attribute" />': {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "JSXElement",
+        "openingElement": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXIdentifier",
+            "name": "div",
+            "range": [
+              1,
+              4
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          },
+          "selfClosing": true,
+          "attributes": [
+            {
+              "type": "JSXSpreadAttribute",
+              "argument": {
+                "type": "Identifier",
+                "name": "props",
+                "range": [
+                  9,
+                  14
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 14
+                  }
+                }
+              },
+              "range": [
+                5,
+                15
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 5
+                },
+                "end": {
+                  "line": 1,
+                  "column": 15
+                }
+              }
+            },
+            {
+              "type": "JSXAttribute",
+              "name": {
+                "type": "JSXIdentifier",
+                "name": "post",
+                "range": [
+                  16,
+                  20
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 20
+                  }
+                }
+              },
+              "value": {
+                "type": "Literal",
+                "value": "attribute",
+                "raw": "\"attribute\"",
+                "range": [
+                  21,
+                  32
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 21
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 32
+                  }
+                }
+              },
+              "range": [
+                16,
+                32
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 32
+                }
+              }
+            }
+          ],
+          "range": [
+            0,
+            35
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 35
+            }
+          }
+        },
+        closingElement: null,
+        "children": [],
+        "range": [
+          0,
+          35
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 35
+          }
+        }
+      },
+      "range": [
+        0,
+        35
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 35
+        }
+      }
+    },
+
+    '<div pre="leading" pre2="attribute" {...props}></div>': {
+      "type": "ExpressionStatement",
+      "expression": {
+        "type": "JSXElement",
+        "openingElement": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXIdentifier",
+            "name": "div",
+            "range": [
+              1,
+              4
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          },
+          "selfClosing": false,
+          "attributes": [
+            {
+              "type": "JSXAttribute",
+              "name": {
+                "type": "JSXIdentifier",
+                "name": "pre",
+                "range": [
+                  5,
+                  8
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 8
+                  }
+                }
+              },
+              "value": {
+                "type": "Literal",
+                "value": "leading",
+                "raw": "\"leading\"",
+                "range": [
+                  9,
+                  18
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 9
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 18
+                  }
+                }
+              },
+              "range": [
+                5,
+                18
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 5
+                },
+                "end": {
+                  "line": 1,
+                  "column": 18
+                }
+              }
+            },
+            {
+              "type": "JSXAttribute",
+              "name": {
+                "type": "JSXIdentifier",
+                "name": "pre2",
+                "range": [
+                  19,
+                  23
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 23
+                  }
+                }
+              },
+              "value": {
+                "type": "Literal",
+                "value": "attribute",
+                "raw": "\"attribute\"",
+                "range": [
+                  24,
+                  35
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 24
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 35
+                  }
+                }
+              },
+              "range": [
+                19,
+                35
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 19
+                },
+                "end": {
+                  "line": 1,
+                  "column": 35
+                }
+              }
+            },
+            {
+              "type": "JSXSpreadAttribute",
+              "argument": {
+                "type": "Identifier",
+                "name": "props",
+                "range": [
+                  40,
+                  45
+                ],
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 40
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 45
+                  }
+                }
+              },
+              "range": [
+                36,
+                46
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 36
+                },
+                "end": {
+                  "line": 1,
+                  "column": 46
+                }
+              }
+            }
+          ],
+          "range": [
+            0,
+            47
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 47
+            }
+          }
+        },
+        "closingElement": {
+          "type": "JSXClosingElement",
+          "name": {
+            "type": "JSXIdentifier",
+            "name": "div",
+            "range": [
+              49,
+              52
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 49
+              },
+              "end": {
+                "line": 1,
+                "column": 52
+              }
+            }
+          },
+          "range": [
+            47,
+            53
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 47
+            },
+            "end": {
+              "line": 1,
+              "column": 53
+            }
+          }
+        },
+        "children": [],
+        "range": [
+          0,
+          53
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 53
+          }
+        }
+      },
+      "range": [
+        0,
+        53
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 53
+        }
+      }
+    },
+
+    '<A aa={aa.bb.cc} bb={bb.cc.dd}><div>{aa.b}</div></A>': {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 52,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 52
+        }
+      },
+      "range": [
+        0,
+        52
+      ],
+      "expression": {
+        "type": "JSXElement",
+        "start": 0,
+        "end": 52,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 52
+          }
+        },
+        "range": [
+          0,
+          52
+        ],
+        "openingElement": {
+          "type": "JSXOpeningElement",
+          "start": 0,
+          "end": 31,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 31
+            }
+          },
+          "range": [
+            0,
+            31
+          ],
+          "attributes": [
+            {
+              "type": "JSXAttribute",
+              "start": 3,
+              "end": 16,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 3
+                },
+                "end": {
+                  "line": 1,
+                  "column": 16
+                }
+              },
+              "range": [
+                3,
+                16
+              ],
+              "name": {
+                "type": "JSXIdentifier",
+                "start": 3,
+                "end": 5,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 5
+                  }
+                },
+                "range": [
+                  3,
+                  5
+                ],
+                "name": "aa"
+              },
+              "value": {
+                "type": "JSXExpressionContainer",
+                "start": 6,
+                "end": 16,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 16
+                  }
+                },
+                "range": [
+                  6,
+                  16
+                ],
+                "expression": {
+                  "type": "MemberExpression",
+                  "start": 7,
+                  "end": 15,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 15
+                    }
+                  },
+                  "range": [
+                    7,
+                    15
+                  ],
+                  "object": {
+                    "type": "MemberExpression",
+                    "start": 7,
+                    "end": 12,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 12
+                      }
+                    },
+                    "range": [
+                      7,
+                      12
+                    ],
+                    "object": {
+                      "type": "Identifier",
+                      "start": 7,
+                      "end": 9,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 9
+                        }
+                      },
+                      "range": [
+                        7,
+                        9
+                      ],
+                      "name": "aa"
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start": 10,
+                      "end": 12,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 12
+                        }
+                      },
+                      "range": [
+                        10,
+                        12
+                      ],
+                      "name": "bb"
+                    },
+                    "computed": false
+                  },
+                  "property": {
+                    "type": "Identifier",
+                    "start": 13,
+                    "end": 15,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 15
+                      }
+                    },
+                    "range": [
+                      13,
+                      15
+                    ],
+                    "name": "cc"
+                  },
+                  "computed": false
+                }
+              }
+            },
+            {
+              "type": "JSXAttribute",
+              "start": 17,
+              "end": 30,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 17
+                },
+                "end": {
+                  "line": 1,
+                  "column": 30
+                }
+              },
+              "range": [
+                17,
+                30
+              ],
+              "name": {
+                "type": "JSXIdentifier",
+                "start": 17,
+                "end": 19,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 17
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 19
+                  }
+                },
+                "range": [
+                  17,
+                  19
+                ],
+                "name": "bb"
+              },
+              "value": {
+                "type": "JSXExpressionContainer",
+                "start": 20,
+                "end": 30,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 30
+                  }
+                },
+                "range": [
+                  20,
+                  30
+                ],
+                "expression": {
+                  "type": "MemberExpression",
+                  "start": 21,
+                  "end": 29,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 21
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 29
+                    }
+                  },
+                  "range": [
+                    21,
+                    29
+                  ],
+                  "object": {
+                    "type": "MemberExpression",
+                    "start": 21,
+                    "end": 26,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 21
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 26
+                      }
+                    },
+                    "range": [
+                      21,
+                      26
+                    ],
+                    "object": {
+                      "type": "Identifier",
+                      "start": 21,
+                      "end": 23,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 21
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 23
+                        }
+                      },
+                      "range": [
+                        21,
+                        23
+                      ],
+                      "name": "bb"
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "start": 24,
+                      "end": 26,
+                      "loc": {
+                        "start": {
+                          "line": 1,
+                          "column": 24
+                        },
+                        "end": {
+                          "line": 1,
+                          "column": 26
+                        }
+                      },
+                      "range": [
+                        24,
+                        26
+                      ],
+                      "name": "cc"
+                    },
+                    "computed": false
+                  },
+                  "property": {
+                    "type": "Identifier",
+                    "start": 27,
+                    "end": 29,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 27
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 29
+                      }
+                    },
+                    "range": [
+                      27,
+                      29
+                    ],
+                    "name": "dd"
+                  },
+                  "computed": false
+                }
+              }
+            }
+          ],
+          "name": {
+            "type": "JSXIdentifier",
+            "start": 1,
+            "end": 2,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 2
+              }
+            },
+            "range": [
+              1,
+              2
+            ],
+            "name": "A"
+          },
+          "selfClosing": false
+        },
+        "closingElement": {
+          "type": "JSXClosingElement",
+          "start": 48,
+          "end": 52,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 48
+            },
+            "end": {
+              "line": 1,
+              "column": 52
+            }
+          },
+          "range": [
+            48,
+            52
+          ],
+          "name": {
+            "type": "JSXIdentifier",
+            "start": 50,
+            "end": 51,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 50
+              },
+              "end": {
+                "line": 1,
+                "column": 51
+              }
+            },
+            "range": [
+              50,
+              51
+            ],
+            "name": "A"
+          }
+        },
+        "children": [
+          {
+            "type": "JSXElement",
+            "start": 31,
+            "end": 48,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 31
+              },
+              "end": {
+                "line": 1,
+                "column": 48
+              }
+            },
+            "range": [
+              31,
+              48
+            ],
+            "openingElement": {
+              "type": "JSXOpeningElement",
+              "start": 31,
+              "end": 36,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 31
+                },
+                "end": {
+                  "line": 1,
+                  "column": 36
+                }
+              },
+              "range": [
+                31,
+                36
+              ],
+              "attributes": [],
+              "name": {
+                "type": "JSXIdentifier",
+                "start": 32,
+                "end": 35,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 32
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 35
+                  }
+                },
+                "range": [
+                  32,
+                  35
+                ],
+                "name": "div"
+              },
+              "selfClosing": false
+            },
+            "closingElement": {
+              "type": "JSXClosingElement",
+              "start": 42,
+              "end": 48,
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 42
+                },
+                "end": {
+                  "line": 1,
+                  "column": 48
+                }
+              },
+              "range": [
+                42,
+                48
+              ],
+              "name": {
+                "type": "JSXIdentifier",
+                "start": 44,
+                "end": 47,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 44
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 47
+                  }
+                },
+                "range": [
+                  44,
+                  47
+                ],
+                "name": "div"
+              }
+            },
+            "children": [
+              {
+                "type": "JSXExpressionContainer",
+                "start": 36,
+                "end": 42,
+                "loc": {
+                  "start": {
+                    "line": 1,
+                    "column": 36
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 42
+                  }
+                },
+                "range": [
+                  36,
+                  42
+                ],
+                "expression": {
+                  "type": "MemberExpression",
+                  "start": 37,
+                  "end": 41,
+                  "loc": {
+                    "start": {
+                      "line": 1,
+                      "column": 37
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 41
+                    }
+                  },
+                  "range": [
+                    37,
+                    41
+                  ],
+                  "object": {
+                    "type": "Identifier",
+                    "start": 37,
+                    "end": 39,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 37
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 39
+                      }
+                    },
+                    "range": [
+                      37,
+                      39
+                    ],
+                    "name": "aa"
+                  },
+                  "property": {
+                    "type": "Identifier",
+                    "start": 40,
+                    "end": 41,
+                    "loc": {
+                      "start": {
+                        "line": 1,
+                        "column": 40
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 41
+                      }
+                    },
+                    "range": [
+                      40,
+                      41
+                    ],
+                    "name": "b"
+                  },
+                  "computed": false
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  'Regression': {
+    '<p>foo <a href="test"> bar</a> baz</p> ;': {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 40,
+      expression: {
+        type: "JSXElement",
+        start: 0,
+        end: 38,
+        openingElement: {
+          type: "JSXOpeningElement",
+          start: 0,
+          end: 3,
+          attributes: [],
+          name: {
+            type: "JSXIdentifier",
+            start: 1,
+            end: 2,
+            name: "p"
+          },
+          selfClosing: false
+        },
+        closingElement: {
+          type: "JSXClosingElement",
+          start: 34,
+          end: 38,
+          name: {
+            type: "JSXIdentifier",
+            start: 36,
+            end: 37,
+            name: "p"
+          }
+        },
+        children: [
+          {
+            type: "Literal",
+            start: 3,
+            end: 7,
+            value: "foo ",
+            raw: "foo "
+          },
+          {
+            type: "JSXElement",
+            start: 7,
+            end: 30,
+            openingElement: {
+              type: "JSXOpeningElement",
+              start: 7,
+              end: 22,
+              attributes: [{
+                type: "JSXAttribute",
+                start: 10,
+                end: 21,
+                name: {
+                  type: "JSXIdentifier",
+                  start: 10,
+                  end: 14,
+                  name: "href"
+                },
+                value: {
+                  type: "Literal",
+                  start: 15,
+                  end: 21,
+                  value: "test",
+                  raw: "\"test\""
+                }
+              }],
+              name: {
+                type: "JSXIdentifier",
+                start: 8,
+                end: 9,
+                name: "a"
+              },
+              selfClosing: false
+            },
+            closingElement: {
+              type: "JSXClosingElement",
+              start: 26,
+              end: 30,
+              name: {
+                type: "JSXIdentifier",
+                start: 28,
+                end: 29,
+                name: "a"
+              }
+            },
+            children: [{
+              type: "Literal",
+              start: 22,
+              end: 26,
+              value: " bar",
+              raw: " bar"
+            }]
+          },
+          {
+            type: "Literal",
+            start: 30,
+            end: 34,
+            value: " baz",
+            raw: " baz"
+          }
+        ]
+      }
+    },
+
+    '<div>{<div {...test} />}</div>': {
+      type: 'ExpressionStatement',
+      start: 0,
+      end: 30,
+      expression: {
+        type: 'JSXElement',
+        start: 0,
+        end: 30,
+        openingElement: {
+          type: 'JSXOpeningElement',
+          start: 0,
+          end: 5,
+          attributes: [],
+          name: {
+            type: 'JSXIdentifier',
+            start: 1,
+            end: 4,
+            name: 'div'
+          },
+          selfClosing: false
+        },
+        closingElement: {
+          type: 'JSXClosingElement',
+          start: 24,
+          end: 30,
+          name: {
+            type: 'JSXIdentifier',
+            start: 26,
+            end: 29,
+            name: 'div'
+          }
+        },
+        children: [{
+          type: 'JSXExpressionContainer',
+          start: 5,
+          end: 24,
+          expression: {
+            type: 'JSXElement',
+            start: 6,
+            end: 23,
+            openingElement: {
+              type: 'JSXOpeningElement',
+              start: 6,
+              end: 23,
+              attributes: [
+                {
+                  type: 'JSXSpreadAttribute',
+                  start: 11,
+                  end: 20,
+                  argument: {
+                    type: 'Identifier',
+                    start: 15,
+                    end: 19,
+                    name: 'test'
+                  }
+                }
+              ],
+              name: {
+                type: 'JSXIdentifier',
+                start: 7,
+                end: 10,
+                name: 'div'
+              },
+              selfClosing: true
+            },
+            closingElement: null,
+            children: []
+          }
+        }]
+      }
+    },
+
+    '<div>{ {a} }</div>': {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 18,
+      expression: {
+        type: "JSXElement",
+        start: 0,
+        end: 18,
+        openingElement: {
+          type: "JSXOpeningElement",
+          start: 0,
+          end: 5,
+          attributes: [],
+          name: {
+            type: "JSXIdentifier",
+            start: 1,
+            end: 4,
+            name: "div"
+          },
+          selfClosing: false
+        },
+        closingElement: {
+          type: "JSXClosingElement",
+          start: 12,
+          end: 18,
+          name: {
+            type: "JSXIdentifier",
+            start: 14,
+            end: 17,
+            name: "div"
+          }
+        },
+        children: [{
+          type: "JSXExpressionContainer",
+          start: 5,
+          end: 12,
+          expression: {
+            type: "ObjectExpression",
+            start: 7,
+            end: 10,
+            properties: [{
+              type: "Property",
+              start: 8,
+              end: 9,
+              method: false,
+              shorthand: true,
+              computed: false,
+              key: {
+                type: "Identifier",
+                start: 8,
+                end: 9,
+                name: "a"
+              },
+              kind: "init",
+              value: {
+                type: "Identifier",
+                start: 8,
+                end: 9,
+                name: "a"
+              }
+            }]
+          }
+        }]
+      }
+    },
+
+    '<div>/text</div>': {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 16,
+      expression: {
+        type: "JSXElement",
+        start: 0,
+        end: 16,
+        openingElement: {
+          type: "JSXOpeningElement",
+          start: 0,
+          end: 5,
+          attributes: [],
+          name: {
+            type: "JSXIdentifier",
+            start: 1,
+            end: 4,
+            name: "div"
+          },
+          selfClosing: false
+        },
+        closingElement: {
+          type: "JSXClosingElement",
+          start: 10,
+          end: 16,
+          name: {
+            type: "JSXIdentifier",
+            start: 12,
+            end: 15,
+            name: "div"
+          }
+        },
+        children: [{
+          type: "Literal",
+          start: 5,
+          end: 10,
+          value: "/text",
+          raw: "/text"
+        }]
+      }
+    },
+
+    '<div>{a}{b}</div>': {
+      type: "ExpressionStatement",
+      start: 0,
+      end: 17,
+      expression: {
+        type: "JSXElement",
+        start: 0,
+        end: 17,
+        openingElement: {
+          type: "JSXOpeningElement",
+          start: 0,
+          end: 5,
+          attributes: [],
+          name: {
+            type: "JSXIdentifier",
+            start: 1,
+            end: 4,
+            name: "div"
+          },
+          selfClosing: false
+        },
+        closingElement: {
+          type: "JSXClosingElement",
+          start: 11,
+          end: 17,
+          name: {
+            type: "JSXIdentifier",
+            start: 13,
+            end: 16,
+            name: "div"
+          }
+        },
+        children: [{
+            type: 'JSXExpressionContainer',
+            expression: {
+              type: 'Identifier',
+              name: 'a',
+              range: [6, 7],
+              loc: {
+                start: {
+                  line: 1,
+                  column: 6
+                },
+                end: {
+                  line: 1,
+                  column: 7
+                }
+              }
+            },
+            range: [5, 8],
+            loc: {
+              start: {
+                line: 1,
+                column: 5
+              },
+              end: {
+                line: 1,
+                column: 8
+              }
+            }
+          }, {
+            type: 'JSXExpressionContainer',
+            expression: {
+              type: 'Identifier',
+              name: 'b',
+              range: [9, 10],
+              loc: {
+                start: {
+                  line: 1,
+                  column: 9
+                },
+                end: {
+                  line: 1,
+                  column: 10
+                }
+              }
+            },
+            range: [8, 11],
+            loc: {
+              start: {
+                line: 1,
+                column: 8
+              },
+              end: {
+                line: 1,
+                column: 11
+              }
+            }
+          }
+        ]
+      }
+    },
+
+    '<div pre="leading" {...props} />': {
+      type: "ExpressionStatement",
+      range: [0, 32],
+      expression: {
+        type: "JSXElement",
+        range: [0, 32],
+        openingElement: {
+          type: "JSXOpeningElement",
+          range: [0, 32],
+          attributes: [
+            {
+              type: "JSXAttribute",
+              range: [5, 18],
+              name: {
+                type: "JSXIdentifier",
+                range: [5, 8],
+                name: "pre"
+              },
+              value: {
+                type: "Literal",
+                range: [9, 18],
+                value: "leading"
+              }
+            },
+            {
+              type: "JSXSpreadAttribute",
+              range: [19, 29],
+              argument: {
+                type: "Identifier",
+                range: [23, 28],
+                name: "props"
+              }
+            }
+          ],
+          name: {
+            type: "JSXIdentifier",
+            range: [1, 4],
+            name: "div"
+          },
+          selfClosing: true
+        },
+        closingElement: null,
+        children: []
+      }
+    },
+    '<path d="M230 80\n\t\tA 45 45, 0, 1, 0, 275 125 \r\n    L 275 80 Z"/>': {
+      type: "ExpressionStatement",
+      expression: {
+        type: "JSXElement",
+        range: [0, 64],
+        openingElement: {
+          type: "JSXOpeningElement",
+          range: [0, 64],
+          attributes: [
+            {
+              type: "JSXAttribute",
+              range: [6, 62],
+              name: {
+                type: "JSXIdentifier",
+                range: [6, 7],
+                name: "d"
+              },
+              value: {
+                type: "Literal",
+                range: [8, 62],
+                value: "M230 80\n\t\tA 45 45, 0, 1, 0, 275 125 \r\n    L 275 80 Z",
+                raw: "\"M230 80\n\t\tA 45 45, 0, 1, 0, 275 125 \r\n    L 275 80 Z\""
+              }
+            }
+          ],
+          name: {
+            type: "JSXIdentifier",
+            range: [1, 5],
+            name: "path"
+          },
+          selfClosing: true
+        },
+        closingElement: null,
+        children: []
+      }
+    }
+  }
+};
+
+if (typeof exports !== "undefined") {
+  var test = require("./driver.js").test;
+}
+
+for (var ns in fbTestFixture) {
+  ns = fbTestFixture[ns];
+  for (var code in ns) {
+    test(code, {
+      type: 'Program',
+      body: [ns[code]]
+    }, {
+      ecmaVersion: 6,
+      locations: true,
+      ranges: true,
+      plugins: ["jsx"],
+      loose: false
+    });
+  }
+}


### PR DESCRIPTION
@RReverser I'd like your opinion on these

The first breaks away from keeping state in closure-global variables. Modern JS engines appear to be able to optimize object sufficiently to be just as fast with a real object, provided you use methods for everything. This is a very invasive change, touching over half the lines in the main file. I think the advantages (reentrancy, easier poking around in the implementation) are worth it, but it does add a lot of object noise.

The second moves the consuming of whitespace to the pre-token-reading routine, rather than doing it after reading a token. This seems saner, but if you can think of a reason why this is problematic, tell me.

The third cleans up the mishmash of object literals used for token types, using a single object shape throughout. This is mostly for efficiency -- it causes a significant speedup. It also makes a few incompatible changes to the token types.