### PR TITLE
Make `readRegexp` more tolerant

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -1040,13 +1040,16 @@
       if (options.ecmaVersion >= 6) validFlags = /^[gmsiyu]*$/;
       if (!validFlags.test(mods)) raise(start, "Invalid regular expression flag");
       if (mods.indexOf('u') >= 0 && !regexpUnicodeSupport) {
-        // Replace each astral symbol and every Unicode code point
-        // escape sequence that represents such a symbol with a single
-        // ASCII symbol to avoid throwing on regular expressions that
+        // Replace each astral symbol and every Unicode escape sequence that
+        // possibly represents an astral symbol or a paired surrogate with a
+        // single ASCII symbol to avoid throwing on regular expressions that
         // are only valid in combination with the `/u` flag.
+        // Note: replacing with the ASCII symbol `x` might cause false
+        // negatives in unlikely scenarios. For example, `[\u{61}-b]` is a
+        // perfectly valid pattern that is equivalent to `[a-b]`, but it would
+        // be replaced by `[x-b]` which throws an error.
         tmp = tmp
-          .replace(/\\u\{([0-9a-fA-F]{5,6})\}/g, "x")
-          .replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "x");
+          .replace(/\\u([a-fA-F0-9]{4})|\\u\{([0-9a-fA-F]+)\}|[\uD800-\uDBFF][\uDC00-\uDFFF]/g, "x")
       }
     }
     // Detect invalid regular expressions.

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13740,6 +13740,34 @@ test("/[a-z]/u", {
   ecmaVersion: 6
 });
 
+test("/[\\uD834\\uDF06-\\uD834\\uDF08a-z]/u", {
+  type: "Program",
+  body: [
+    {
+      type: "ExpressionStatement",
+      expression: {
+        type: "Literal",
+        regex: {
+          pattern: "[\\uD834\\uDF06-\\uD834\\uDF08a-z]",
+          flags: "u"
+        },
+        loc: {
+          start: {
+            line: 1,
+            column: 0
+          },
+          end: {
+            line: 1,
+            column: 33
+          }
+        }
+      }
+    }
+  ]
+}, {
+  locations: true,
+  ecmaVersion: 6
+});
 
 test("do {} while (false) foo();", {
   type: "Program",


### PR DESCRIPTION
E.g.

```js
/[\uD834\uDF06-\uD834\uDF08a-z]/u
```

This is perfectly valid ES6 (given the `u` flag) but it didn’t parse.

This patch accounts for this case as well by using a regex to look for `\uXXXX` escape sequences and replacing them with a hardcoded ASCII letter `x` (like we previously did for `\u{…}` escapes).