### PR TITLE
AssignmentExpression required for ES6 ComputedPropertyName

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2514,7 +2514,7 @@
     if (options.ecmaVersion >= 6) {
       if (eat(_bracketL)) {
         prop.computed = true;
-        prop.key = parseExpression();
+        prop.key = parseMaybeAssign();
         expect(_bracketR);
         return;
       } else {

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13902,6 +13902,8 @@ testFail("yield v", "Unexpected token (1:6)", {ecmaVersion: 6});
 
 testFail("yield 10", "Unexpected token (1:6)", {ecmaVersion: 6});
 
+testFail("void { [1, 2]: 3 };", "Unexpected token (1:9)", {ecmaVersion: 6});
+
 test("yield* 10", {
   type: "Program",
   body: [{


### PR DESCRIPTION
`{ [1, 2]: 3 }` should be invalid in ES6.