### PR TITLE
Add assertions for better error messages

### DIFF
--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -1,5 +1,7 @@
 // AST walker module for Mozilla Parser API compatible trees
 
+import assert from 'assert';
+
 // A simple walk is one where you simply specify callbacks to be
 // called on specific nodes. The last two arguments are optional. A
 // simple use would be
@@ -20,6 +22,7 @@ export function simple(node, visitors, base, state) {
   if (!base) base = exports.base
   ;(function c(node, st, override) {
     let type = override || node.type, found = visitors[type]
+    assert(base[type], type + ' did not have a handler')
     base[type](node, st, c)
     if (found) found(node, st)
   })(node, state)
@@ -36,6 +39,7 @@ export function ancestor(node, visitors, base, state) {
       st = st.slice()
       st.push(node)
     }
+    assert(base[type], type + ' did not have a handler')
     base[type](node, st, c)
     if (found) found(node, st)
   })(node, state)
@@ -49,6 +53,7 @@ export function ancestor(node, visitors, base, state) {
 export function recursive(node, state, funcs, base) {
   let visitor = funcs ? exports.make(funcs, base) : base
   ;(function c(node, st, override) {
+    assert(visitor[override || node.type], (override || node.type) + ' did not have a handler')
     visitor[override || node.type](node, st, c)
   })(node, state)
 }


### PR DESCRIPTION
Before this change I get:

```
TypeError: undefined is not a function
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:77:15)
  at Object.base.ImportDeclaration (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:318:5)
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:77:15)
  at Object.skipThrough (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:182:3)
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:77:15)
  at Object.base.Program.base.BlockStatement (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:193:5)
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:77:15)
  at Object.ancestor (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:79:5)
  at findGlobals (/Users/forbeslindesay/GitHub/acorn-globals/index.js:55:8)
  at /Users/forbeslindesay/GitHub/acorn-globals/test/index.js:31:20
```

After this change I get:

```
AssertionError: ImportDefaultSpecifier did not have a handler
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:77:22)
  at Object.base.ImportDeclaration (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:319:5)
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:78:15)
  at Object.skipThrough (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:183:3)
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:78:15)
  at Object.base.Program.base.BlockStatement (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:194:5)
  at c (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:78:15)
  at Object.ancestor (/Users/forbeslindesay/GitHub/acorn-globals/node_modules/acorn/dist/walk.js:80:5)
  at findGlobals (/Users/forbeslindesay/GitHub/acorn-globals/index.js:55:8)
  at /Users/forbeslindesay/GitHub/acorn-globals/test/index.js:31:20
```

Which is much easier to debug.