### PR TITLE
Add support for using with browserify

### DIFF
--- a/bin/derequire.js
+++ b/bin/derequire.js
@@ -1,0 +1,14 @@
+var fs = require("fs");
+var derequire = require("derequire");
+
+function derequireFile(filename) {
+  fs.writeFileSync(
+    filename,
+    derequire(
+      fs.readFileSync(filename, 'utf8')
+    )
+  );
+}
+derequireFile(__dirname + '/../dist/acorn.js');
+derequireFile(__dirname + '/../dist/acorn_loose.js');
+derequireFile(__dirname + '/../dist/walk.js');

--- a/bin/prepublish.sh
+++ b/bin/prepublish.sh
@@ -1,2 +1,3 @@
 node bin/build-acorn.js
+node bin/derequire.js
 node bin/without_eval > dist/acorn_csp.js

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "babelify": "^5.0.4",
     "browserify": "^9.0.3",
+    "derequire": "^2.0.0",
     "unicode-7.0.0": "~0.1.5"
   }
 }


### PR DESCRIPTION
When the switch was made to using browserify as a build step within acorn, it broke usage of acorn within browserify apps.  Unfortunately browserify is not clever enough to work recursively.  This is unlikely to get fixed because it's difficult to fix without destroying performance.  This uses derequire to allow people to use acorn from within browserify.