### PR TITLE
acorn now parses also js files with shebang

### DIFF
--- a/bin/acorn
+++ b/bin/acorn
@@ -31,6 +31,7 @@ for (var i = 2; i < process.argv.length; ++i) {
 
 try {
   var code = fs.readFileSync(infile, "utf8");
+  code = code.replace(/^#!.*(\r\n?|\n)/,""); //remove shebang if present
 
   if (!tokenize)
     parsed = acorn.parse(code, options);


### PR DESCRIPTION
If the parsed file contains shebang (e.g. `#!/usr/bin/env node`),
acorn ends up with an error: `Unexpected character '#' (1:0)`.

This can be fixed by removing the shebang before parsing.