### PR TITLE
Add additional type-annotation related methods

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -125,14 +125,22 @@ pp.parseBindingList = function(close, allowEmpty, allowTrailingComma) {
     } else if (allowTrailingComma && this.afterTrailingComma(close)) {
       break
     } else if (this.type === tt.ellipsis) {
-      elts.push(this.parseRest())
+      let rest = this.parseRest()
+      this.parseBindingListItem(rest)
+      elts.push(rest)
       this.expect(close)
       break
     } else {
-      elts.push(this.parseMaybeDefault(this.start, this.startLoc))
+      let elem = this.parseMaybeDefault(this.start, this.startLoc)
+      this.parseBindingListItem(elem)
+      elts.push(elem)
     }
   }
   return elts
+}
+
+pp.parseBindingListItem = function(param) {
+  return param
 }
 
 // Parses assignment pattern around given atom if possible.


### PR DESCRIPTION
All added methods are necessary in order to support alternate syntax extensions such as Flow (for my use-case) and likely TypeScript too.

One thing this PR doesn't do is implement the same methods for the loose parser. Happy to add those if necessary, unsure if method/plugin parity and parameters are a priority.

Please feel free to be pedantic as I'm more than happy to change method names or justify the existence of them.

Thanks!