### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,7 @@
     "type": "git",
     "url": "https://github.com/marijnh/acorn.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.githubusercontent.com/marijnh/acorn/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "node test/run.js",
     "prepublish": "bin/prepublish.sh"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/