### PR TITLE
Fix parser function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,6 @@ export function tokenizer(input, options) {
   return parser(options, input)
 }
 
-function parser(options, input) {
-  return new Parser(getOptions(options), String(input))
+function parser(options, input, pos) {
+  return new Parser(getOptions(options), String(input), pos)
 }


### PR DESCRIPTION
Currently `parseExpressionAt` accepts an `offset`, but does't works. This PR fixed that.