### PR TITLE
Added flag for parsing modules in console tool

### DIFF
--- a/bin/acorn
+++ b/bin/acorn
@@ -9,7 +9,7 @@ var infile, parsed, tokens, options = {}, silent = false, compact = false, token
 function help(status) {
   var print = (status == 0) ? console.log : console.error;
   print("usage: " + path.basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6]");
-  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--help] [--] infile");
+  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--module] [--help] [--] infile");
   process.exit(status);
 }
 
@@ -27,6 +27,7 @@ for (var i = 2; i < process.argv.length; ++i) {
   else if (arg == "--compact") compact = true;
   else if (arg == "--help") help(0);
   else if (arg == "--tokenize") tokenize = true;
+  else if (arg == "--module") options.sourceType = 'module';
   else help(1);
 }
 

--- a/bin/acorn
+++ b/bin/acorn
@@ -9,7 +9,7 @@ var infile, parsed, tokens, options = {}, silent = false, compact = false, token
 function help(status) {
   var print = (status == 0) ? console.log : console.error;
   print("usage: " + path.basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6]");
-  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--sourceType=TYPE] [--help] [--] infile");
+  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--sourceType TYPE] [--help] [--] infile");
   process.exit(status);
 }
 
@@ -28,7 +28,6 @@ for (var i = 2; i < process.argv.length; ++i) {
   else if (arg == "--help") help(0);
   else if (arg == "--tokenize") tokenize = true;
   else if (arg == "--sourceType") options.sourceType = process.argv[++i];
-  else if (arg.substr(0, 13) == "--sourceType=") options.sourceType = arg.substr(13);
   else help(1);
 }
 

--- a/bin/acorn
+++ b/bin/acorn
@@ -9,7 +9,7 @@ var infile, parsed, tokens, options = {}, silent = false, compact = false, token
 function help(status) {
   var print = (status == 0) ? console.log : console.error;
   print("usage: " + path.basename(process.argv[1]) + " [--ecma3|--ecma5|--ecma6]");
-  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--module] [--help] [--] infile");
+  print("        [--tokenize] [--locations] [---allow-hash-bang] [--compact] [--silent] [--sourceType=TYPE] [--help] [--] infile");
   process.exit(status);
 }
 
@@ -27,9 +27,8 @@ for (var i = 2; i < process.argv.length; ++i) {
   else if (arg == "--compact") compact = true;
   else if (arg == "--help") help(0);
   else if (arg == "--tokenize") tokenize = true;
-  else if (arg == "--sourceType") {
-    options.sourceType = process.argv[++i];
-  }
+  else if (arg == "--sourceType") options.sourceType = process.argv[++i];
+  else if (arg.substr(0, 13) == "--sourceType=") options.sourceType = arg.substr(13);
   else help(1);
 }
 

--- a/bin/acorn
+++ b/bin/acorn
@@ -27,7 +27,9 @@ for (var i = 2; i < process.argv.length; ++i) {
   else if (arg == "--compact") compact = true;
   else if (arg == "--help") help(0);
   else if (arg == "--tokenize") tokenize = true;
-  else if (arg == "--module") options.sourceType = 'module';
+  else if (arg == "--sourceType") {
+    options.sourceType = process.argv[++i];
+  }
   else help(1);
 }
 


### PR DESCRIPTION
This enables the command line tool `acorn` to parse module files when necessary.
Previously, it failed by raising and error with the message: `'import' and 'export' may appear only with 'sourceType: module'`.