### PR TITLE
Browserify loose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.tern-port
 /local
 /dist
+/test/browserify.js

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
   },
   "license": "MIT",
   "scripts": {
-    "prepublish": "node bin/build-acorn.js && node bin/without_eval > dist/acorn_csp.js",
-    "test": "node test/run.js"
+    "build": "node bin/build-acorn.js && node bin/without_eval > dist/acorn_csp.js",
+    "prepublish": "npm run build",
+    "pretest": "npm run build && browserify test/run-dist.js > test/browserify.js",
+    "test": "node test/run.js && node test/run-dist.js && node test/browserify.js"
   },
   "bin": {
     "acorn": "./bin/acorn"
@@ -36,6 +38,7 @@
     "babelify": "^6.1.2",
     "browserify": "^10.2.4",
     "browserify-derequire": "^0.9.4",
+    "is-browser": "^2.0.1",
     "unicode-7.0.0": "~0.1.5"
   }
 }

--- a/test/browserify.html
+++ b/test/browserify.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<head>
+  <meta charset="utf-8">
+  <title>Acorn test suite</title>
+</head>
+<body>
+  <ul id="log"></ul>
+  <script src="browserify.js"></script>
+</body>

--- a/test/index.html
+++ b/test/index.html
@@ -10,5 +10,6 @@
 </head>
 <body>
   <ul id="log"></ul>
-  <script src="run.js"></script>
+  <script src="runner.js"></script>
+  <script>run(acorn, window);</script>
 </body>

--- a/test/run-dist.js
+++ b/test/run-dist.js
@@ -1,0 +1,12 @@
+var IS_BROWSER = require('is-browser');
+
+var runner = require('./runner.js');
+
+var driver = require("./driver.js");
+require("./tests.js");
+require("./tests-harmony.js");
+
+var acorn = require("../dist/acorn");
+require("../dist/acorn_loose");
+
+runner(acorn, driver, IS_BROWSER ? 'Test Browserify' : 'Test Dist');

--- a/test/run.js
+++ b/test/run.js
@@ -1,113 +1,13 @@
-(function() {
-  var driver, acorn;
+'use strict';
 
-  if (typeof require !== "undefined") {
-    driver = require("./driver.js");
-    require("./tests.js");
-    require("./tests-harmony.js");
-    require("babel-core/register")
-    acorn = require("../src")
-    require("../src/loose")
-  } else {
-    driver = window;
-    acorn = window.acorn;
-  }
+var runner = require('./runner.js');
 
-  var htmlLog = typeof document === "object" && document.getElementById('log');
-  var htmlGroup = htmlLog;
+var driver = require("./driver.js");
+require("./tests.js");
+require("./tests-harmony.js");
 
-  function group(name) {
-    if (htmlGroup) {
-      var parentGroup = htmlGroup;
-      htmlGroup = document.createElement("ul");
-      var item = document.createElement("li");
-      item.textContent = name;
-      item.appendChild(htmlGroup);
-      parentGroup.appendChild(item);
-    }
-    if (typeof console === "object" && console.group) {
-      console.group(name);
-    }
-  }
+require("babel-core/register");
+var acorn = require("../src");
+require("../src/loose");
 
-  function groupEnd() {
-    if (htmlGroup) {
-      htmlGroup = htmlGroup.parentElement.parentElement;
-    }
-    if (typeof console === "object" && console.groupEnd) {
-      console.groupEnd(name);
-    }
-  }
-
-  function log(title, message) {
-    if (htmlGroup) {
-      var elem = document.createElement("li");
-      elem.innerHTML = "<b>" + title + "</b> " + message;
-      htmlGroup.appendChild(elem);
-    }
-    if (typeof console === "object") console.log(title, message);
-  }
-
-  var stats, modes = {
-    Normal: {
-      config: {
-        parse: acorn.parse
-      }
-    },
-    Loose: {
-      config: {
-        parse: acorn.parse_dammit,
-        loose: true,
-        filter: function (test) {
-          var opts = test.options || {};
-          if (opts.loose === false) return false;
-          return (opts.ecmaVersion || 5) <= 6;
-        }
-      }
-    }
-  };
-
-  function report(state, code, message) {
-    if (state != "ok") {++stats.failed; log(code, message);}
-    ++stats.testsRun;
-  }
-
-  group("Errors");
-
-  for (var name in modes) {
-    group(name);
-    var mode = modes[name];
-    stats = mode.stats = {testsRun: 0, failed: 0};
-    var t0 = +new Date;
-    driver.runTests(mode.config, report);
-    mode.stats.duration = +new Date - t0;
-    groupEnd();
-  }
-
-  groupEnd();
-
-  function outputStats(name, stats) {
-    log(name + ":", stats.testsRun + " tests run in " + stats.duration + "ms; " +
-      (stats.failed ? stats.failed + " failures." : "all passed."));
-  }
-
-  var total = {testsRun: 0, failed: 0, duration: 0};
-
-  group("Stats");
-
-  for (var name in modes) {
-    var stats = modes[name].stats;
-    outputStats(name + " parser", stats);
-    for (var key in stats) total[key] += stats[key];
-  }
-
-  outputStats("Total", total);
-
-  groupEnd();
-
-  if (total.failed && typeof process === "object") {
-    process.stdout.write("", function() {
-      process.exit(1);
-    });
-  }
-})();
+runner(acorn, driver, 'Test Source');

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,0 +1,122 @@
+(function () {
+
+  var htmlLog = typeof document === "object" && document.getElementById('log');
+  var htmlGroup = htmlLog;
+  var logIndent = '';
+
+  function group(name) {
+    if (htmlGroup) {
+      var parentGroup = htmlGroup;
+      htmlGroup = document.createElement("ul");
+      var item = document.createElement("li");
+      item.textContent = name;
+      item.appendChild(htmlGroup);
+      parentGroup.appendChild(item);
+    }
+    if (typeof console === "object" && console.group) {
+      console.group(name);
+    } else if (typeof console === 'object') {
+      console.log(logIndent + name);
+      logIndent += '  ';
+    }
+  }
+
+  function groupEnd() {
+    if (htmlGroup) {
+      htmlGroup = htmlGroup.parentElement.parentElement;
+    }
+    if (typeof console === "object" && console.groupEnd) {
+      console.groupEnd(name);
+    } else if (typeof console === 'object') {
+      logIndent = logIndent.substr(0, logIndent.length - 2);
+    }
+  }
+
+  function log(title, message) {
+    if (htmlGroup) {
+      var elem = document.createElement("li");
+      elem.innerHTML = "<b>" + title + "</b> " + message;
+      htmlGroup.appendChild(elem);
+    }
+    if (typeof console === "object") console.log(logIndent + title, message);
+  }
+
+  function run(acorn, driver, title) {
+
+    if (title) group(title);
+
+    var stats, modes = {
+      Normal: {
+        config: {
+          parse: acorn.parse
+        }
+      },
+      Loose: {
+        config: {
+          parse: acorn.parse_dammit,
+          loose: true,
+          filter: function (test) {
+            var opts = test.options || {};
+            if (opts.loose === false) return false;
+            return (opts.ecmaVersion || 5) <= 6;
+          }
+        }
+      }
+    };
+
+    function report(state, code, message) {
+      if (state != "ok") {++stats.failed; log(code, message);}
+      ++stats.testsRun;
+    }
+
+    group("Errors");
+
+    for (var name in modes) {
+      group(name);
+      var mode = modes[name];
+      stats = mode.stats = {testsRun: 0, failed: 0};
+      var t0 = +new Date;
+      driver.runTests(mode.config, report);
+      mode.stats.duration = +new Date - t0;
+      if (mode.stats.failed === 0) {
+        log("", "all passed");
+      }
+      groupEnd();
+    }
+
+    groupEnd();
+
+    function outputStats(name, stats) {
+      log(name + ":", stats.testsRun + " tests run in " + stats.duration + "ms; " +
+        (stats.failed ? stats.failed + " failures." : "all passed."));
+    }
+
+    var total = {testsRun: 0, failed: 0, duration: 0};
+
+    group("Stats");
+
+    for (var name in modes) {
+      var stats = modes[name].stats;
+      outputStats(name + " parser", stats);
+      for (var key in stats) total[key] += stats[key];
+    }
+
+    outputStats("Total", total);
+
+    groupEnd();
+
+    if (total.failed && typeof process === "object") {
+      process.stdout.write("", function() {
+        process.exit(1);
+      });
+    }
+    
+    if (title) groupEnd();
+  }
+
+  if (typeof require !== 'undefined') {
+    module.exports = run;
+  } else {
+    window.run = run;
+  }
+}());


### PR DESCRIPTION
We need the `require` call to be ignored in the first pass, which is
why it was inserted as `_dereq_` in the first place.  This is needed in
case the user is loading acorn and acorn_loose/acorn_walk as separate
script tags.

However, if the file is loaded via browserify (i.e. a second browserify
pass) we need that require to be processed, which wasn't working before
because it had been renamed to `_dereq_`.

This is fixed by using a placeholder, which gets swapped out after the
first browserify pass has completed.