### PR TITLE
Fix support for `let` as an ES2015 identifer – deductive

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -90,7 +90,7 @@ pp.parseSpread = function(refShorthandDefaultPos) {
 pp.parseRest = function() {
   let node = this.startNode()
   this.next()
-  node.argument = this.type === tt.name || this.type === tt.bracketL ? this.parseBindingAtom() : this.unexpected()
+  node.argument = this.type === tt.name || this.type === tt._let || this.type === tt.bracketL ? this.parseBindingAtom() : this.unexpected()
   return this.finishNode(node, "RestElement")
 }
 
@@ -99,6 +99,7 @@ pp.parseRest = function() {
 pp.parseBindingAtom = function() {
   if (this.options.ecmaVersion < 6) return this.parseIdent()
   switch (this.type) {
+  case tt._let:
   case tt.name:
     return this.parseIdent()
 

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -735,3 +735,13 @@ pp.readWord = function() {
     type = keywordTypes[word]
   return this.finishToken(type, word)
 }
+
+// Check if the token starts a LexicalDeclaration.
+
+pp.checkLexicalDeclarationToken = function(tok) {
+  return tok.type === tt.name ||
+         tok.type === tt._let ||
+      // tok.type === tt._yield ||
+         tok.type === tt.braceL ||
+         tok.type === tt.bracketL
+}

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -46,6 +46,61 @@ pp.getToken = function() {
   return new Token(this)
 }
 
+pp.saveState = function() {
+  return {
+    containsEsc: this.containsEsc,
+    lineStart: this.lineStart,
+    pos: this.pos,
+    curLine: this.curLine,
+    type: this.type,
+    value: this.value,
+    start: this.start,
+    end: this.end,
+    startLoc: this.startLoc,
+    endLoc: this.endLoc,
+    lastTokStart: this.lastTokStart,
+    lastTokEnd: this.lastTokEnd,
+    lastTokStartLoc: this.lastTokStartLoc,
+    lastTokEndLoc: this.lastTokEndLoc,
+    context: this.context.slice(),
+    exprAllowed: this.exprAllowed,
+    strict: this.strict,
+    potentialArrowAt: this.potentialArrowAt,
+    inGenerator: this.inGenerator,
+    inFunction: this.inFunction
+  }
+}
+
+pp.restoreState = function(old) {
+  this.containsEsc = old.containsEsc
+  this.lineStart = old.lineStart
+  this.pos = old.pos
+  this.curLine = old.curLine
+  this.type = old.type
+  this.value = old.value
+  this.start = old.start
+  this.end = old.end
+  this.startLoc = old.startLoc
+  this.endLoc = old.endLoc
+  this.lastTokStart = old.lastTokStart
+  this.lastTokEnd = old.lastTokEnd
+  this.lastTokStartLoc = old.lastTokStartLoc
+  this.lastTokEndLoc = old.lastTokEndLoc
+  this.context = old.context
+  this.exprAllowed = old.exprAllowed
+  this.strict = old.strict
+  this.potentialArrowAt = old.potentialArrowAt
+  this.inGenerator = old.inGenerator
+  this.inFunction = old.inFunction
+}
+
+pp.lookahead = function() {
+  var old = this.saveState()
+  var token = this.getToken()
+  this.restoreState(old)
+  return token
+}
+
 // If we're in an ES6 environment, make parsers iterable
 if (typeof Symbol !== "undefined")
   pp[Symbol.iterator] = function () {

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15399,3 +15399,79 @@ test("({ get __proto__() { return 1 }, __proto__: 2 })", {}, {ecmaVersion: 6});
 test("({ __proto__, __proto__: 2 })", {}, {ecmaVersion: 6});
 
 test("export default /foo/", {}, {ecmaVersion: 6, sourceType: "module"});
+
+// https://github.com/marijnh/acorn/issues/227
+
+test("var let", {
+  type: "Program",
+  start: 0,
+  end: 7,
+  loc: {
+    start: {
+      line: 1,
+      column: 0
+    },
+    end: {
+      line: 1,
+      column: 7
+    }
+  },
+  body: [
+    {
+      type: "VariableDeclaration",
+      start: 0,
+      end: 7,
+      loc: {
+        start: {
+          line: 1,
+          column: 0
+        },
+        end: {
+          line: 1,
+          column: 7
+        }
+      },
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          start: 4,
+          end: 7,
+          loc: {
+            start: {
+              line: 1,
+              column: 4
+            },
+            end: {
+              line: 1,
+              column: 7
+            }
+          },
+          id: {
+            type: "Identifier",
+            start: 4,
+            end: 7,
+            loc: {
+              start: {
+                line: 1,
+                column: 4
+              },
+              end: {
+                line: 1,
+                column: 7
+              }
+            },
+            name: "let"
+          },
+          init: null
+        }
+      ],
+      kind: "var"
+    }
+  ],
+  sourceType: "script"
+}, {
+  ecmaVersion: 6,
+  ranges: true,
+  locations: true
+})
+testFail("const let = 0", "Unexpected token (1:6)", {ecmaVersion: 6})


### PR DESCRIPTION
**DO NOT MERGE!!!** This is a work-in-progress.

This PR works by starting with _let tokens, and then change the tokens to name tokens when we are sure they are identifiers. This approach breaks fewer existing cases, but is kind of ugly because of all the `this.type === tt.name || this.type === tt._let` changes. There is also a possibility that some such checks are missed or forgotten.

TODO:

- Fix loose parser

---

The second commit causes the output of `onToken` and `tokenizer` to be different: the former outputs a `name` token with value `let` while the latter outputs a `let` token.

There is also the question of the validity of `const let`. ES2015 [13.3.1.1](http://www.ecma-international.org/ecma-262/6.0/#sec-let-and-const-declarations-static-semantics-early-errors) says:

> *LexicalDeclaration* **:** *LetOrConst* *BindingList* **;**
>
> - It is a Syntax Error if the BoundNames of *BindingList* contains `"let"`.
> - It is a Syntax Error if the BoundNames of *BindingList* contains any duplicate entries.

If I'm understanding this passage correctly, it's saying that `let let` and `const let` are both not valid. Esprima supports this claim.

In V8 however `const let = 0` works fine.

Fixes part of #227. `var yield` still fails to parse.