### PR TITLE
Add checking for arrow function duplicate parameters

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -164,7 +164,7 @@ pp.checkLVal = function(expr, isBinding, checkClashes) {
       this.raise(expr.start, (isBinding ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
     if (checkClashes) {
       if (has(checkClashes, expr.name))
-        this.raise(expr.start, "Argument name clash in strict mode")
+        this.raise(expr.start, "Argument name clash")
       checkClashes[expr.name] = true
     }
     break

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -1713,7 +1713,6 @@ test("([a, , b]) => 42", {
 });
 
 testFail("([a.a]) => 42", "Assigning to rvalue (1:2)", {ecmaVersion: 6});
-
 testFail("console.log(typeof () => {});", "Unexpected token (1:20)", {ecmaVersion: 6})
 
 test("(x=1) => x * x", {
@@ -2445,62 +2444,6 @@ test("foo((x, y) => {})", {
     start: {line: 1, column: 0},
     end: {line: 1, column: 17}
   }
-}, {
-  ecmaVersion: 6,
-  ranges: true,
-  locations: true
-});
-
-test("(a, a) => 42", {
-  type: "Program",
-  loc: {
-    start: {line: 1, column: 0},
-    end: {line: 1, column: 12}
-  },
-  body: [{
-    type: "ExpressionStatement",
-    loc: {
-      start: {line: 1, column: 0},
-      end: {line: 1, column: 12}
-    },
-    expression: {
-      type: "ArrowFunctionExpression",
-      loc: {
-        start: {line: 1, column: 0},
-        end: {line: 1, column: 12}
-      },
-      id: null,
-      params: [
-        {
-          type: "Identifier",
-          loc: {
-            start: {line: 1, column: 1},
-            end: {line: 1, column: 2}
-          },
-          name: "a"
-        },
-        {
-          type: "Identifier",
-          loc: {
-            start: {line: 1, column: 4},
-            end: {line: 1, column: 5}
-          },
-          name: "a"
-        }
-      ],
-      generator: false,
-      body: {
-        type: "Literal",
-        loc: {
-          start: {line: 1, column: 10},
-          end: {line: 1, column: 12}
-        },
-        value: 42,
-        raw: "42"
-      },
-      expression: true
-    }
-  }]
 }, {
   ecmaVersion: 6,
   ranges: true,
@@ -13740,7 +13683,7 @@ testFail("function default() {}", "Unexpected token (1:9)", {ecmaVersion: 6});
 
 testFail("function hello() {'use strict'; ({ i: 10, s(eval) { } }); }", "Binding eval in strict mode (1:44)", {ecmaVersion: 6});
 
-testFail("function a() { \"use strict\"; ({ b(t, t) { } }); }", "Argument name clash in strict mode (1:37)", {ecmaVersion: 6});
+testFail("function a() { \"use strict\"; ({ b(t, t) { } }); }", "Argument name clash (1:37)", {ecmaVersion: 6});
 
 testFail("var super", "Unexpected token (1:4)", {ecmaVersion: 6});
 
@@ -13780,7 +13723,9 @@ testFail("\"use strict\"; (arguments, a) => 42", "Binding arguments in strict mo
 
 testFail("\"use strict\"; (eval, a = 10) => 42", "Binding eval in strict mode (1:15)", {ecmaVersion: 6});
 
-testFail("\"use strict\"; (a, a) => 42", "Argument name clash in strict mode (1:18)", {ecmaVersion: 6});
+testFail("(a, a) => 42", "Argument name clash (1:4)", {ecmaVersion: 6});
+
+testFail("\"use strict\"; (a, a) => 42", "Argument name clash (1:18)", {ecmaVersion: 6});
 
 testFail("\"use strict\"; (a) => 00", "Invalid number (1:21)", {ecmaVersion: 6});
 
@@ -14016,11 +13961,11 @@ testFail("function f(a, ...b = 0)", "Unexpected token (1:19)", {ecmaVersion: 6})
 
 testFail("function x(...{ a }){}", "Unexpected token (1:14)", {ecmaVersion: 6});
 
-testFail("\"use strict\"; function x(a, { a }){}", "Argument name clash in strict mode (1:30)", {ecmaVersion: 6});
+testFail("\"use strict\"; function x(a, { a }){}", "Argument name clash (1:30)", {ecmaVersion: 6});
 
-testFail("\"use strict\"; function x({ b: { a } }, [{ b: { a } }]){}", "Argument name clash in strict mode (1:47)", {ecmaVersion: 6});
+testFail("\"use strict\"; function x({ b: { a } }, [{ b: { a } }]){}", "Argument name clash (1:47)", {ecmaVersion: 6});
 
-testFail("\"use strict\"; function x(a, ...[a]){}", "Argument name clash in strict mode (1:32)", {ecmaVersion: 6});
+testFail("\"use strict\"; function x(a, ...[a]){}", "Argument name clash (1:32)", {ecmaVersion: 6});
 
 testFail("(...a, b) => {}", "Unexpected token (1:5)", {ecmaVersion: 6});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -27392,7 +27392,7 @@ testFail("\"use strict\"; function static() { }",
          "The keyword 'static' is reserved (1:23)");
 
 testFail("function a(t, t) { \"use strict\"; }",
-         "Argument name clash in strict mode (1:14)");
+         "Argument name clash (1:14)");
 
 testFail("function a(eval) { \"use strict\"; }",
          "Binding eval in strict mode (1:11)");
@@ -27401,13 +27401,13 @@ testFail("function a(package) { \"use strict\"; }",
          "Binding package in strict mode (1:11)");
 
 testFail("function a() { \"use strict\"; function b(t, t) { }; }",
-         "Argument name clash in strict mode (1:43)");
+         "Argument name clash (1:43)");
 
 testFail("(function a(t, t) { \"use strict\"; })",
-         "Argument name clash in strict mode (1:15)");
+         "Argument name clash (1:15)");
 
 testFail("function a() { \"use strict\"; (function b(t, t) { }); }",
-         "Argument name clash in strict mode (1:44)");
+         "Argument name clash (1:44)");
 
 testFail("(function a(eval) { \"use strict\"; })",
          "Binding eval in strict mode (1:12)");


### PR DESCRIPTION
This one isn't as clean as my last PR, so feel free to tell that this isn't the right way to do things.

I split out parameter checking into its own function so I could use it in a couple of places. The tricky part for arrow functions is that it should check parameters outside of strict mode.

Fixes #325 
