### PR TITLE
Make sure that exports \{default\} throws an error

### DIFF
--- a/src/statement.js
+++ b/src/statement.js
@@ -526,6 +526,13 @@ pp.parseExport = function(node) {
     if (this.eatContextual("from")) {
       node.source = this.type === tt.string ? this.parseExprAtom() : this.unexpected()
     } else {
+      // check for keywords used as local names
+      for (let i = 0; i < node.specifiers.length; i++) {
+        if (this.keywords.test(node.specifiers[i].local.name) || this.reservedWords.test(node.specifiers[i].local.name)) {
+          this.unexpected(node.specifiers[i].local.start)
+        }
+      }
+
       node.source = null
     }
     this.semicolon()

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -4977,6 +4977,12 @@ test("export { default } from \"other\"", {
   locations: true
 });
 
+testFail("export { default }", "Unexpected token (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("export { if }", "Unexpected token (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("export { if } from 'foo'", "Unexpected token (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("export { default as foo }", "Unexpected token (1:9)", {ecmaVersion: 6, sourceType: "module" });
+testFail("export { if as foo }", "Unexpected token (1:9)", {ecmaVersion: 6, sourceType: "module" });
+
 test("import \"jquery\"", {
   type: "Program",
   body: [{


### PR DESCRIPTION
This checks if the local name of an export specifier is a keyword or reserved word only when there's no `from` clause (the case with a `from` clause appears to already work, though I'm not sure why).

Fixes #326 
