### PR TITLE
Ensure arrow functions are in parens for call

### DIFF
--- a/src/expression.js
+++ b/src/expression.js
@@ -205,7 +205,8 @@ pp.parseMaybeUnary = function(refShorthandDefaultPos) {
 pp.parseExprSubscripts = function(refShorthandDefaultPos) {
   let startPos = this.start, startLoc = this.startLoc
   let expr = this.parseExprAtom(refShorthandDefaultPos)
-  if (refShorthandDefaultPos && refShorthandDefaultPos.start) return expr
+  let skipArrowSubscripts = expr.type === "ArrowFunctionExpression" && this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")";
+  if ((refShorthandDefaultPos && refShorthandDefaultPos.start) || skipArrowSubscripts) return expr
   return this.parseSubscripts(expr, startPos, startLoc)
 }
 

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -1713,7 +1713,101 @@ test("([a, , b]) => 42", {
 });
 
 testFail("([a.a]) => 42", "Assigning to rvalue (1:2)", {ecmaVersion: 6});
+testFail("() => {}()", "Unexpected token (1:8)", {ecmaVersion: 6})
+testFail("(a) => {}()", "Unexpected token (1:9)", {ecmaVersion: 6})
+testFail("a => {}()", "Unexpected token (1:7)", {ecmaVersion: 6})
 testFail("console.log(typeof () => {});", "Unexpected token (1:20)", {ecmaVersion: 6})
+
+test("(() => {})()", {
+  type: "Program",
+  body: [{
+    type: "ExpressionStatement",
+    expression: {
+        type: "CallExpression",
+        start: 0,
+        end: 12,
+        callee: {
+          type: "ArrowFunctionExpression",
+          id: null,
+          params: [],
+          body: {
+            type: "BlockStatement",
+            body: [],
+            start: 7,
+            end: 9,
+            loc: {
+              start: {line: 1, column: 7},
+              end: {line: 1, column: 9}
+            }
+          },
+          generator: false,
+          expression: false,
+          loc: {
+            start: {line: 1, column: 1},
+            end: {line: 1, column: 9}
+          }
+        }
+    },
+    loc: {
+      start: {line: 1, column: 0},
+      end: {line: 1, column: 12}
+    }
+  }],
+  loc: {
+    start: {line: 1, column: 0},
+    end: {line: 1, column: 12}
+  }
+}, {
+  ecmaVersion: 6,
+  ranges: true,
+  locations: true
+});
+
+test("((() => {}))()", {
+  type: "Program",
+  body: [{
+    type: "ExpressionStatement",
+    expression: {
+        type: "CallExpression",
+        start: 0,
+        end: 14,
+        callee: {
+          type: "ArrowFunctionExpression",
+          id: null,
+          params: [],
+          body: {
+            type: "BlockStatement",
+            body: [],
+            start: 8,
+            end: 10,
+            loc: {
+              start: {line: 1, column: 8},
+              end: {line: 1, column: 10}
+            }
+          },
+          generator: false,
+          expression: false,
+          loc: {
+            start: {line: 1, column: 2},
+            end: {line: 1, column: 10}
+          }
+        }
+    },
+    loc: {
+      start: {line: 1, column: 0},
+      end: {line: 1, column: 14}
+    }
+  }],
+  loc: {
+    start: {line: 1, column: 0},
+    end: {line: 1, column: 14}
+  }
+}, {
+  ecmaVersion: 6,
+  ranges: true,
+  locations: true
+});
+
 
 test("(x=1) => x * x", {
   type: "Program",


### PR DESCRIPTION
I'm using the trick Espree currently uses (Esprima did away with it) in order to track parentheses while parsing. This is reasonably clean (IMO) and doesn't involve significant refactoring.

Fixes #333